### PR TITLE
Upgrade GPMP2 to use latest GTSAM

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -62,7 +62,7 @@ jobs:
           fi
       - name: Install Dependencies
         run: |
-          sudo apt-get -y install cmake build-essential pkg-config libpython-dev python-numpy libicu-dev
+          sudo apt-get -y install cmake build-essential pkg-config libicu-dev
           sudo apt-get -y install libtbb-dev libboost-all-dev
 
           # Install CppUnitLite.

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -18,22 +18,22 @@ jobs:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
         name: [
-          ubuntu-18.04-gcc-9,
-          ubuntu-18.04-clang-9,
+          ubuntu-20.04-gcc-9,
+          ubuntu-20.04-clang-10,
         ]
 
         build_type: [Debug, Release]
         build_unstable: [ON]
         include:
-          - name: ubuntu-18.04-gcc-9
-            os: ubuntu-18.04
+          - name: ubuntu-20.04-gcc-9
+            os: ubuntu-20.04
             compiler: gcc
             version: "9"
 
-          - name: ubuntu-18.04-clang-9
-            os: ubuntu-18.04
+          - name: ubuntu-20.04-clang-10
+            os: ubuntu-20.04
             compiler: clang
-            version: "9"
+            version: "10"
 
     steps:
       - name: Setup Compiler

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -17,35 +17,32 @@ jobs:
       matrix:
         # Github Actions requires a single row to be added to the build matrix.
         # See https://help.github.com/en/articles/workflow-syntax-for-github-actions.
-        name: [macos-11-xcode-13.4.1]
+        name: [macOS-12-xcode-14.2]
 
         build_type: [Debug, Release]
-        build_unstable: [ON]
         include:
-          - name: macos-11-xcode-13.4.1
-            os: macOS-11
+          - name: macOS-12-xcode-14.2
+            os: macOS-12
             compiler: xcode
-            version: "13.4.1"
+            version: "14.2"
 
     steps:
       - name: Setup Compiler
         run: |
-          sudo xcode-select -switch /Applications/Xcode.app
+          sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Dependencies
         run: |
           brew install boost
+          brew tap osrf/simulation
+          brew install sdformat12
+          brew tap borglab/core
 
       - name: GTSAM
         run: |
-          git clone https://github.com/borglab/gtsam.git
-          cd gtsam
-          mkdir build && cd build
-          cmake -D GTSAM_BUILD_EXAMPLES_ALWAYS=OFF ..
-          make -j$(sysctl -n hw.physicalcpu) install
-          cd ../../ # go back to home directory
+          run: brew install --HEAD gtsam@latest
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -36,13 +36,10 @@ jobs:
       - name: Dependencies
         run: |
           brew install boost
-          brew tap osrf/simulation
-          brew install sdformat12
           brew tap borglab/core
 
       - name: GTSAM
-        run: |
-          run: brew install --HEAD gtsam@latest
+        run: brew install --HEAD gtsam@latest
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build*
 *.pyc
+**/.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 enable_testing()
 project(gpmp2
         LANGUAGES CXX C
-        VERSION 0.3.0)
+        VERSION 1.0.0)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 
@@ -29,6 +29,13 @@ set(GPMP2_VERSION_STRING gpmp2_VERSION_STRING)
 option(GPMP2_BUILD_STATIC_LIBRARY "whether build static library" OFF)
 option(GPMP2_BUILD_MATLAB_TOOLBOX "whether build matlab toolbox, need shared lib" OFF)
 option(GPMP2_BUILD_PYTHON_TOOLBOX "whether build python toolbox, need shared lib" OFF)
+
+# Enable or disable serialization with GPMP2_ENABLE_BOOST_SERIALIZATION
+option(GPMP2_ENABLE_BOOST_SERIALIZATION "Enable Boost serialization" ON)
+if(GPMP2_ENABLE_BOOST_SERIALIZATION)
+  add_compile_definitions(GTSAM_ENABLE_BOOST_SERIALIZATION)
+  add_compile_definitions(GPMP2_ENABLE_BOOST_SERIALIZATION)
+endif()
 
 if(GPMP2_BUILD_STATIC_LIBRARY AND GPMP2_BUILD_MATLAB_TOOLBOX)
   message(FATAL_ERROR "Matlab toolbox needs static lib to be built")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 
 add_compile_options(-faligned-new)
 
-# Enforce c++11 standards
-add_compile_options(-std=c++11) # CMake 3.1 and earlier
-set(CMAKE_CXX_STANDARD 11)
+# Enforce c++17 standards
+add_compile_options(-std=c++17) # CMake 3.1 and earlier
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+#TODO(Varun) Verify C++17 is enabled on Windows as well
+# Look at GtsamBuildTypes L153
 
 # Mac ONLY. Define Relative Path on Mac OS
 if(NOT DEFINED CMAKE_MACOSX_RPATH)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,18 @@ This library is an implementation of GPMP2 (Gaussian Process Motion Planner 2) a
   pip install cython numpy scipy matplotlib
   ```
 
-- Install gpmp2.
+- Install the `gtwrap` project.
+  
+  If you compile and install GTSAM with the python wrapper enabled, you will automatically have `gtwrap` and you can continue to the next step.
+  Else, please clone and install the [gtwrap project](https://github.com/borglab/wrap).
+
+  ```sh
+  git clone git@github.com:borglab/wrap.git
+  mkdir build && cd build
+  cmake .. && make install
+  ```
+
+- Install `gpmp2`.
   ```bash
   git clone https://github.com/borglab/gpmp2.git
   cd gpmp2 && mkdir build && cd build

--- a/doc/CplusplusDevelopment.md
+++ b/doc/CplusplusDevelopment.md
@@ -52,7 +52,7 @@ class Arm : public ForwardKinematics<gtsam::Vector, gtsam::Vector> {
   /// the base pose (default zero pose), and theta bias (default zero)
   Arm(size_t dof, const gtsam::Vector& a, const gtsam::Vector& alpha, const gtsam::Vector& d,
       const gtsam::Pose3& base_pose = gtsam::Pose3(gtsam::Rot3(), gtsam::Point3(0,0,0)),
-      boost::optional<const gtsam::Vector&> theta_bias = boost::none);
+      std::optional<const gtsam::Vector> theta_bias = {});
   ...
 ```
 

--- a/gpmp2/CMakeLists.txt
+++ b/gpmp2/CMakeLists.txt
@@ -3,7 +3,7 @@
 # The following variable is the master list of subdirs to add
 set(gpmp2_subdirs 
     geometry
-    gp 
+    gp
     kinematics
     dynamics
     obstacle

--- a/gpmp2/dynamics/VehicleDynamics.h
+++ b/gpmp2/dynamics/VehicleDynamics.h
@@ -16,8 +16,8 @@ namespace gpmp2 {
 /// direction return sliding velocity for Lie group, lower is better
 inline double simple2DVehicleDynamicsPose2(
     const gtsam::Pose2& p, const gtsam::Vector3& v,
-    gtsam::OptionalJacobian<1, 3> Hp = boost::none,
-    gtsam::OptionalJacobian<1, 3> Hv = boost::none) {
+    gtsam::OptionalJacobian<1, 3> Hp = {},
+    gtsam::OptionalJacobian<1, 3> Hv = {}) {
   if (Hp) *Hp = (gtsam::Matrix13() << 0, 0, 0).finished();
   if (Hv) *Hv = (gtsam::Matrix13() << 0, 1, 0).finished();
 
@@ -28,8 +28,8 @@ inline double simple2DVehicleDynamicsPose2(
 /// direction return sliding velocity for vector space, lower is better
 inline double simple2DVehicleDynamicsVector3(
     const gtsam::Vector3& p, const gtsam::Vector3& v,
-    gtsam::OptionalJacobian<1, 3> Hp = boost::none,
-    gtsam::OptionalJacobian<1, 3> Hv = boost::none) {
+    gtsam::OptionalJacobian<1, 3> Hp = {},
+    gtsam::OptionalJacobian<1, 3> Hv = {}) {
   if (Hp)
     *Hp = (gtsam::Matrix13() << 0, 0, -(v(1) * sin(p(2)) + v(0) * cos(p(2))))
               .finished();

--- a/gpmp2/dynamics/VehicleDynamicsFactorPose2.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorPose2.h
@@ -88,6 +88,7 @@ class VehicleDynamicsFactorPose2
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -95,6 +96,7 @@ class VehicleDynamicsFactorPose2
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/dynamics/VehicleDynamicsFactorPose2.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorPose2.h
@@ -22,11 +22,11 @@ namespace gpmp2 {
  * unary factor for vehicle dynamics
  */
 class VehicleDynamicsFactorPose2
-    : public gtsam::NoiseModelFactor2<gtsam::Pose2, gtsam::Vector> {
+    : public gtsam::NoiseModelFactorN<gtsam::Pose2, gtsam::Vector> {
  private:
   // typedefs
   typedef VehicleDynamicsFactorPose2 This;
-  typedef gtsam::NoiseModelFactor2<gtsam::Pose2, gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<gtsam::Pose2, gtsam::Vector> Base;
 
  public:
   /// shorthand for a smart pointer to a factor
@@ -48,10 +48,10 @@ class VehicleDynamicsFactorPose2
 
   /// error function
   /// numerical/analytic Jacobians from cost function
-  gtsam::Vector evaluateError(const gtsam::Pose2& pose,
-                              const gtsam::Vector& vel,
-                              std::optional<gtsam::Matrix> H1 = nullptr,
-                              std::optional<gtsam::Matrix> H2 = nullptr) const {
+  gtsam::Vector evaluateError(
+      const gtsam::Pose2& pose, const gtsam::Vector& vel,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr) const override {
     using namespace gtsam;
 
     if (H1 || H2) {

--- a/gpmp2/dynamics/VehicleDynamicsFactorPose2.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorPose2.h
@@ -30,7 +30,7 @@ class VehicleDynamicsFactorPose2
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   VehicleDynamicsFactorPose2() {}
@@ -48,10 +48,10 @@ class VehicleDynamicsFactorPose2
 
   /// error function
   /// numerical/analytic Jacobians from cost function
-  gtsam::Vector evaluateError(
-      const gtsam::Pose2& pose, const gtsam::Vector& vel,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Pose2& pose,
+                              const gtsam::Vector& vel,
+                              std::optional<gtsam::Matrix> H1 = nullptr,
+                              std::optional<gtsam::Matrix> H2 = nullptr) const {
     using namespace gtsam;
 
     if (H1 || H2) {
@@ -76,7 +76,7 @@ class VehicleDynamicsFactorPose2
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/dynamics/VehicleDynamicsFactorPose2Vector.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorPose2Vector.h
@@ -24,11 +24,11 @@ namespace gpmp2 {
  * unary factor for vehicle dynamics
  */
 class VehicleDynamicsFactorPose2Vector
-    : public gtsam::NoiseModelFactor2<Pose2Vector, gtsam::Vector> {
+    : public gtsam::NoiseModelFactorN<Pose2Vector, gtsam::Vector> {
  private:
   // typedefs
   typedef VehicleDynamicsFactorPose2Vector This;
-  typedef gtsam::NoiseModelFactor2<Pose2Vector, gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<Pose2Vector, gtsam::Vector> Base;
 
  public:
   /// shorthand for a smart pointer to a factor
@@ -50,9 +50,10 @@ class VehicleDynamicsFactorPose2Vector
 
   /// error function
   /// numerical/analytic Jacobians from cost function
-  gtsam::Vector evaluateError(const Pose2Vector& conf, const gtsam::Vector& vel,
-                              std::optional<gtsam::Matrix> H1 = {},
-                              std::optional<gtsam::Matrix> H2 = {}) const {
+  gtsam::Vector evaluateError(
+      const Pose2Vector& conf, const gtsam::Vector& vel,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr) const override {
     using namespace gtsam;
 
     if (H1 || H2) {

--- a/gpmp2/dynamics/VehicleDynamicsFactorPose2Vector.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorPose2Vector.h
@@ -32,7 +32,7 @@ class VehicleDynamicsFactorPose2Vector
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   VehicleDynamicsFactorPose2Vector() {}
@@ -50,10 +50,9 @@ class VehicleDynamicsFactorPose2Vector
 
   /// error function
   /// numerical/analytic Jacobians from cost function
-  gtsam::Vector evaluateError(
-      const Pose2Vector& conf, const gtsam::Vector& vel,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none) const {
+  gtsam::Vector evaluateError(const Pose2Vector& conf, const gtsam::Vector& vel,
+                              std::optional<gtsam::Matrix> H1 = {},
+                              std::optional<gtsam::Matrix> H2 = {}) const {
     using namespace gtsam;
 
     if (H1 || H2) {
@@ -79,7 +78,7 @@ class VehicleDynamicsFactorPose2Vector
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/dynamics/VehicleDynamicsFactorPose2Vector.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorPose2Vector.h
@@ -91,6 +91,7 @@ class VehicleDynamicsFactorPose2Vector
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -98,6 +99,7 @@ class VehicleDynamicsFactorPose2Vector
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/dynamics/VehicleDynamicsFactorVector.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorVector.h
@@ -89,6 +89,7 @@ class VehicleDynamicsFactorVector
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -96,6 +97,7 @@ class VehicleDynamicsFactorVector
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor2", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/dynamics/VehicleDynamicsFactorVector.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorVector.h
@@ -22,11 +22,11 @@ namespace gpmp2 {
  * unary factor for vehicle dynamics
  */
 class VehicleDynamicsFactorVector
-    : public gtsam::NoiseModelFactor2<gtsam::Vector, gtsam::Vector> {
+    : public gtsam::NoiseModelFactorN<gtsam::Vector, gtsam::Vector> {
  private:
   // typedefs
   typedef VehicleDynamicsFactorVector This;
-  typedef gtsam::NoiseModelFactor2<gtsam::Vector, gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<gtsam::Vector, gtsam::Vector> Base;
 
  public:
   /// shorthand for a smart pointer to a factor
@@ -48,10 +48,10 @@ class VehicleDynamicsFactorVector
 
   /// error function
   /// numerical/analytic Jacobians from cost function
-  gtsam::Vector evaluateError(const gtsam::Vector& conf,
-                              const gtsam::Vector& vel,
-                              std::optional<gtsam::Matrix> H1 = {},
-                              std::optional<gtsam::Matrix> H2 = {}) const {
+  gtsam::Vector evaluateError(
+      const gtsam::Vector& conf, const gtsam::Vector& vel,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr) const override {
     using namespace gtsam;
 
     if (H1 || H2) {

--- a/gpmp2/dynamics/VehicleDynamicsFactorVector.h
+++ b/gpmp2/dynamics/VehicleDynamicsFactorVector.h
@@ -30,7 +30,7 @@ class VehicleDynamicsFactorVector
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   VehicleDynamicsFactorVector() {}
@@ -48,10 +48,10 @@ class VehicleDynamicsFactorVector
 
   /// error function
   /// numerical/analytic Jacobians from cost function
-  gtsam::Vector evaluateError(
-      const gtsam::Vector& conf, const gtsam::Vector& vel,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Vector& conf,
+                              const gtsam::Vector& vel,
+                              std::optional<gtsam::Matrix> H1 = {},
+                              std::optional<gtsam::Matrix> H2 = {}) const {
     using namespace gtsam;
 
     if (H1 || H2) {
@@ -77,7 +77,7 @@ class VehicleDynamicsFactorVector
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/dynamics/tests/testVehicleDynamics.cpp
+++ b/gpmp2/dynamics/tests/testVehicleDynamics.cpp
@@ -27,16 +27,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsPose2) {
   p = Pose2();
   v = Vector3::Zero();
   cexp = 0;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Pose2&)>(
-          std::bind(simple2DVehicleDynamicsPose2, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsPose2, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Pose2&)>(std::bind(
+                                simple2DVehicleDynamicsPose2,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsPose2, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsPose2(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -46,16 +45,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsPose2) {
   p = Pose2(1.0, 2.0, 0.3);
   v = (Vector3() << 0, 0, 1.2).finished();
   cexp = 0;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Pose2&)>(
-          std::bind(simple2DVehicleDynamicsPose2, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsPose2, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Pose2&)>(std::bind(
+                                simple2DVehicleDynamicsPose2,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsPose2, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsPose2(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -65,16 +63,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsPose2) {
   p = Pose2(1.0, 2.0, M_PI * 0.75);
   v = (Vector3() << -1, 1, 1.2).finished();
   cexp = 1;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Pose2&)>(
-          std::bind(simple2DVehicleDynamicsPose2, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsPose2, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Pose2&)>(std::bind(
+                                simple2DVehicleDynamicsPose2,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsPose2, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsPose2(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -84,16 +81,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsPose2) {
   p = Pose2(1.0, 2.0, M_PI * 0.75);
   v = (Vector3() << 0, 1, 1.2).finished();
   cexp = 1;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Pose2&)>(
-          std::bind(simple2DVehicleDynamicsPose2, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsPose2, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Pose2&)>(std::bind(
+                                simple2DVehicleDynamicsPose2,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsPose2, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsPose2(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -103,16 +99,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsPose2) {
   p = Pose2(34.6, -31.2, 1.75);
   v = (Vector3() << 14.3, 6.7, 22.2).finished();
   cexp = 6.7;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Pose2&)>(
-          std::bind(simple2DVehicleDynamicsPose2, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsPose2, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Pose2&)>(std::bind(
+                                simple2DVehicleDynamicsPose2,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsPose2, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsPose2(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -129,16 +124,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsVector3) {
   p = Vector3::Zero();
   v = Vector3::Zero();
   cexp = 0;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                simple2DVehicleDynamicsVector3,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsVector3, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsVector3(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -148,16 +142,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsVector3) {
   p = (Vector3() << 1.0, 2.0, 0.3).finished();
   v = (Vector3() << 0, 0, 1.2).finished();
   cexp = 0;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                simple2DVehicleDynamicsVector3,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsVector3, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsVector3(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -167,16 +160,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsVector3) {
   p = (Vector3() << 1.0, 2.0, M_PI * 0.75).finished();
   v = (Vector3() << -1, 1, 1.2).finished();
   cexp = 0;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                simple2DVehicleDynamicsVector3,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsVector3, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsVector3(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -186,16 +178,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsVector3) {
   p = (Vector3() << 1.0, 2.0, M_PI * 0.75).finished();
   v = (Vector3() << 0, 1, 1.2).finished();
   cexp = -0.707106781186548;
-  Hpexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                simple2DVehicleDynamicsVector3,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsVector3, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsVector3(p, v, Hpact, Hvact);
   EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));
@@ -204,16 +195,15 @@ TEST(VehicleDynamics, simple2DVehicleDynamicsVector3) {
   // random stuff for Jacobians
   p = (Vector3() << 34.6, -31.2, 1.75).finished();
   v = (Vector3() << 14.3, 6.7, 22.2).finished();
-  Hpexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, std::placeholders::_1, v,
-                    boost::none, boost::none)),
-      p);
-  Hvexp = numericalDerivative11(
-      std::function<double(const Vector3&)>(
-          std::bind(simple2DVehicleDynamicsVector3, p, std::placeholders::_1,
-                    boost::none, boost::none)),
-      v);
+  Hpexp =
+      numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                simple2DVehicleDynamicsVector3,
+                                std::placeholders::_1, v, nullptr, nullptr)),
+                            p);
+  Hvexp = numericalDerivative11(std::function<double(const Vector3&)>(std::bind(
+                                    simple2DVehicleDynamicsVector3, p,
+                                    std::placeholders::_1, nullptr, nullptr)),
+                                v);
   cact = simple2DVehicleDynamicsVector3(p, v, Hpact, Hvact);
   // EXPECT_DOUBLES_EQUAL(cexp, cact, 1e-9);
   EXPECT(assert_equal(Hpexp, Hpact, 1e-6));

--- a/gpmp2/geometry/DynamicLieTraits.h
+++ b/gpmp2/geometry/DynamicLieTraits.h
@@ -39,42 +39,39 @@ struct DynamicLieGroupTraits {
   static int GetDimension(const Class& m) { return m.dim(); }
 
   static TangentVector Local(const Class& origin, const Class& other,
-                             ChartJacobian Horigin = boost::none,
-                             ChartJacobian Hother = boost::none) {
+                             ChartJacobian Horigin = {},
+                             ChartJacobian Hother = {}) {
     return origin.localCoordinates(other, Horigin, Hother);
   }
 
   static Class Retract(const Class& origin, const TangentVector& v,
-                       ChartJacobian Horigin = boost::none,
-                       ChartJacobian Hv = boost::none) {
+                       ChartJacobian Horigin = {}, ChartJacobian Hv = {}) {
     return origin.retract(v, Horigin, Hv);
   }
   /// @}
 
   /// @name Lie Group
   /// @{
-  static TangentVector Logmap(const Class& m, ChartJacobian Hm = boost::none) {
+  static TangentVector Logmap(const Class& m, ChartJacobian Hm = {}) {
     return Class::Logmap(m, Hm);
   }
 
-  static Class Expmap(const TangentVector& v, ChartJacobian Hv = boost::none) {
+  static Class Expmap(const TangentVector& v, ChartJacobian Hv = {}) {
     return Class::Expmap(v, Hv);
   }
 
   static Class Compose(const Class& m1, const Class& m2,  //
-                       ChartJacobian H1 = boost::none,
-                       ChartJacobian H2 = boost::none) {
+                       ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
     return m1.compose(m2, H1, H2);
   }
 
   static Class Between(const Class& m1, const Class& m2,  //
-                       ChartJacobian H1 = boost::none,
-                       ChartJacobian H2 = boost::none) {
+                       ChartJacobian H1 = {}, ChartJacobian H2 = {}) {
     return m1.between(m2, H1, H2);
   }
 
   static Class Inverse(const Class& m,  //
-                       ChartJacobian H = boost::none) {
+                       ChartJacobian H = {}) {
     return m.inverse(H);
   }
   /// @}

--- a/gpmp2/geometry/DynamicVector.h
+++ b/gpmp2/geometry/DynamicVector.h
@@ -38,7 +38,7 @@ class GPMP2_EXPORT DynamicVector {
   DynamicVector(const Eigen::VectorXd& vector)
       : dim_(vector.size()), vector_(vector) {}
 
-  virtual ~DynamicVector() {}
+  ~DynamicVector() {}
 
   // access element for convenience
   double operator()(size_t i) const { return vector_(i); }

--- a/gpmp2/geometry/ProductDynamicLieGroup.h
+++ b/gpmp2/geometry/ProductDynamicLieGroup.h
@@ -20,8 +20,8 @@ namespace gpmp2 {
 template <typename G, typename H>
 class ProductDynamicLieGroup : public std::pair<G, H> {
  private:
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<G>));
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<H>));
+  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<G>));
+  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<H>));
   typedef std::pair<G, H> Base;
 
  protected:
@@ -84,8 +84,8 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
   typedef gtsam::OptionalJacobian<dimension, dimension> ChartJacobian;
 
   ProductDynamicLieGroup retract(const TangentVector& v,  //
-                                 ChartJacobian H1 = boost::none,
-                                 ChartJacobian H2 = boost::none) const {
+                                 ChartJacobian H1 = {},
+                                 ChartJacobian H2 = {}) const {
     if (H1 || H2)
       throw std::runtime_error(
           "ProductLieGroup::retract derivatives not implemented yet");
@@ -95,8 +95,8 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
   }
 
   TangentVector localCoordinates(const ProductDynamicLieGroup& g,  //
-                                 ChartJacobian H1 = boost::none,
-                                 ChartJacobian H2 = boost::none) const {
+                                 ChartJacobian H1 = {},
+                                 ChartJacobian H2 = {}) const {
     if (H1 || H2)
       throw std::runtime_error(
           "ProductLieGroup::localCoordinates derivatives not implemented yet");
@@ -120,7 +120,7 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
  public:
   ProductDynamicLieGroup compose(const ProductDynamicLieGroup& other,
                                  ChartJacobian H1,
-                                 ChartJacobian H2 = boost::none) const {
+                                 ChartJacobian H2 = {}) const {
     if (H1 || H2) {
       Jacobian1 D_g_first;
       Jacobian2 D_h_second;
@@ -143,7 +143,7 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
 
   ProductDynamicLieGroup between(const ProductDynamicLieGroup& other,
                                  ChartJacobian H1,
-                                 ChartJacobian H2 = boost::none) const {
+                                 ChartJacobian H2 = {}) const {
     if (H1 || H2) {
       Jacobian1 D_g_first;
       Jacobian2 D_h_second;
@@ -182,7 +182,7 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
   }
 
   static ProductDynamicLieGroup Expmap(const TangentVector& v,
-                                       ChartJacobian Hv = boost::none) {
+                                       ChartJacobian Hv = {}) {
     // figure out total dim from v input
     const size_t dim_v = v.size();
     // figure out dim for 1 and 2
@@ -218,7 +218,7 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
   }
 
   static TangentVector Logmap(const ProductDynamicLieGroup& p,
-                              ChartJacobian Hp = boost::none) {
+                              ChartJacobian Hp = {}) {
     if (Hp) {
       Jacobian1 D_g_first;
       Jacobian2 D_h_second;

--- a/gpmp2/geometry/numericalDerivativeDynamic.h
+++ b/gpmp2/geometry/numericalDerivativeDynamic.h
@@ -14,9 +14,6 @@
 #include <gtsam/linear/VectorValues.h>
 #include <gtsam/nonlinear/Values.h>
 
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-
 namespace gpmp2 {
 
 template <class Y, class X>
@@ -24,14 +21,14 @@ gtsam::Matrix numericalDerivativeDynamic(const std::function<Y(const X&)> h,
                                          const X& x, double delta = 1e-5) {
   BOOST_STATIC_ASSERT_MSG(
       (std::is_base_of<gtsam::manifold_tag,
-                         typename gtsam::traits<Y>::structure_category>::value),
+                       typename gtsam::traits<Y>::structure_category>::value),
       "Template argument Y must be a manifold type.");
   typedef gtsam::traits<Y> TraitsY;
   typedef typename TraitsY::TangentVector TangentY;
 
   BOOST_STATIC_ASSERT_MSG(
       (std::is_base_of<gtsam::manifold_tag,
-                         typename gtsam::traits<X>::structure_category>::value),
+                       typename gtsam::traits<X>::structure_category>::value),
       "Template argument X must be a manifold type.");
   static const int N =
       DimensionUtils<X, gtsam::traits<X>::dimension>::getDimension(x);

--- a/gpmp2/geometry/numericalDerivativeDynamic.h
+++ b/gpmp2/geometry/numericalDerivativeDynamic.h
@@ -23,14 +23,14 @@ template <class Y, class X>
 gtsam::Matrix numericalDerivativeDynamic(const std::function<Y(const X&)> h,
                                          const X& x, double delta = 1e-5) {
   BOOST_STATIC_ASSERT_MSG(
-      (boost::is_base_of<gtsam::manifold_tag,
+      (std::is_base_of<gtsam::manifold_tag,
                          typename gtsam::traits<Y>::structure_category>::value),
       "Template argument Y must be a manifold type.");
   typedef gtsam::traits<Y> TraitsY;
   typedef typename TraitsY::TangentVector TangentY;
 
   BOOST_STATIC_ASSERT_MSG(
-      (boost::is_base_of<gtsam::manifold_tag,
+      (std::is_base_of<gtsam::manifold_tag,
                          typename gtsam::traits<X>::structure_category>::value),
       "Template argument X must be a manifold type.");
   static const int N =

--- a/gpmp2/geometry/tests/testDynamicVector.cpp
+++ b/gpmp2/geometry/tests/testDynamicVector.cpp
@@ -25,10 +25,10 @@ GTSAM_CONCEPT_LIE_INST(DynamicVector)
 
 /* ************************************************************************** */
 TEST(DynamicVector, Concept) {
-  BOOST_CONCEPT_ASSERT((IsGroup<DynamicVector>));
-  BOOST_CONCEPT_ASSERT((IsManifold<DynamicVector>));
-  BOOST_CONCEPT_ASSERT((IsLieGroup<DynamicVector>));
-  BOOST_CONCEPT_ASSERT((IsVectorSpace<DynamicVector>));
+  GTSAM_CONCEPT_ASSERT((IsGroup<DynamicVector>));
+  GTSAM_CONCEPT_ASSERT((IsManifold<DynamicVector>));
+  GTSAM_CONCEPT_ASSERT((IsLieGroup<DynamicVector>));
+  GTSAM_CONCEPT_ASSERT((IsVectorSpace<DynamicVector>));
 }
 
 /* ************************************************************************** */

--- a/gpmp2/geometry/tests/testPose2Vector.cpp
+++ b/gpmp2/geometry/tests/testPose2Vector.cpp
@@ -22,9 +22,9 @@ using namespace gpmp2;
 
 /* ************************************************************************** */
 TEST(Pose2Vector, Lie) {
-  BOOST_CONCEPT_ASSERT((IsGroup<Pose2Vector>));
-  BOOST_CONCEPT_ASSERT((IsManifold<Pose2Vector>));
-  BOOST_CONCEPT_ASSERT((IsLieGroup<Pose2Vector>));
+  GTSAM_CONCEPT_ASSERT((IsGroup<Pose2Vector>));
+  GTSAM_CONCEPT_ASSERT((IsManifold<Pose2Vector>));
+  GTSAM_CONCEPT_ASSERT((IsLieGroup<Pose2Vector>));
 }
 
 /* ************************************************************************** */

--- a/gpmp2/geometry/tests/testProductDynamicLieGroup.cpp
+++ b/gpmp2/geometry/tests/testProductDynamicLieGroup.cpp
@@ -47,9 +47,9 @@ struct traits<Product> : internal::DynamicLieGroupTraits<Product> {
 
 //******************************************************************************
 TEST(ProductDynamicLieGroup, ProductLieGroup) {
-  BOOST_CONCEPT_ASSERT((IsGroup<Product>));
-  BOOST_CONCEPT_ASSERT((IsManifold<Product>));
-  BOOST_CONCEPT_ASSERT((IsLieGroup<Product>));
+  GTSAM_CONCEPT_ASSERT((IsGroup<Product>));
+  GTSAM_CONCEPT_ASSERT((IsManifold<Product>));
+  GTSAM_CONCEPT_ASSERT((IsLieGroup<Product>));
   Product pair1(Point2(0, 0), Pose2());
   Vector5 d;
   d << 1, 2, 0.1, 0.2, 0.3;

--- a/gpmp2/gp/GaussianProcessInterpolatorLie.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLie.h
@@ -13,6 +13,7 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/MatrixSerialization.h>
 #include <gtsam/base/Vector.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 #include <iostream>
 
@@ -55,8 +56,8 @@ class GaussianProcessInterpolatorLie {
     Psi_ = calcPsi(Qc_, delta_t_, tau_);
   }
 
-  /** Virtual destructor */
-  virtual ~GaussianProcessInterpolatorLie() {}
+  /** Destructor */
+  ~GaussianProcessInterpolatorLie() {}
 
   /// interpolate pose with Jacobians
   T interpolatePose(
@@ -106,12 +107,15 @@ class GaussianProcessInterpolatorLie {
   }
 
   /// update jacobian based on interpolated jacobians
-  static void updatePoseJacobians(
-      const gtsam::Matrix& Hpose, const gtsam::Matrix& Hint1,
-      const gtsam::Matrix& Hint2, const gtsam::Matrix& Hint3,
-      const gtsam::Matrix& Hint4, std::optional<gtsam::Matrix> H1,
-      std::optional<gtsam::Matrix> H2, std::optional<gtsam::Matrix> H3,
-      std::optional<gtsam::Matrix> H4) {
+  static void updatePoseJacobians(const gtsam::Matrix& Hpose,
+                                  const gtsam::Matrix& Hint1,
+                                  const gtsam::Matrix& Hint2,
+                                  const gtsam::Matrix& Hint3,
+                                  const gtsam::Matrix& Hint4,
+                                  gtsam::OptionalMatrixType H1 = nullptr,
+                                  gtsam::OptionalMatrixType H2 = nullptr,
+                                  gtsam::OptionalMatrixType H3 = nullptr,
+                                  gtsam::OptionalMatrixType H4 = nullptr) {
     if (H1) *H1 = Hpose * Hint1;
     if (H2) *H2 = Hpose * Hint2;
     if (H3) *H3 = Hpose * Hint3;
@@ -161,7 +165,7 @@ class GaussianProcessInterpolatorLie {
    */
 
   /** equals specialized to this factor */
-  virtual bool equals(const This& expected, double tol = 1e-9) const {
+  bool equals(const This& expected, double tol = 1e-9) const {
     return fabs(this->delta_t_ - expected.delta_t_) < tol &&
            fabs(this->tau_ - expected.tau_) < tol &&
            gtsam::equal_with_abs_tol(this->Qc_, expected.Qc_, tol) &&

--- a/gpmp2/gp/GaussianProcessInterpolatorLie.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLie.h
@@ -182,6 +182,7 @@ class GaussianProcessInterpolatorLie {
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -193,6 +194,7 @@ class GaussianProcessInterpolatorLie {
     ar& BOOST_SERIALIZATION_NVP(Lambda_);
     ar& BOOST_SERIALIZATION_NVP(Psi_);
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/gp/GaussianProcessInterpolatorLie.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLie.h
@@ -25,7 +25,7 @@ namespace gpmp2 {
 template <typename T>
 class GaussianProcessInterpolatorLie {
  private:
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
   typedef GaussianProcessInterpolatorLie<T> This;
 
   size_t dof_;
@@ -62,11 +62,10 @@ class GaussianProcessInterpolatorLie {
   T interpolatePose(
       const T& pose1, const gtsam::Vector& vel1, const T& pose2,
       const gtsam::Vector& vel2,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 =
-          boost::none) const {
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 = {}) const {
     using namespace gtsam;
 
     const Vector r1 = (Vector(2 * dof_) << Vector::Zero(dof_), vel1).finished();
@@ -110,9 +109,9 @@ class GaussianProcessInterpolatorLie {
   static void updatePoseJacobians(
       const gtsam::Matrix& Hpose, const gtsam::Matrix& Hint1,
       const gtsam::Matrix& Hint2, const gtsam::Matrix& Hint3,
-      const gtsam::Matrix& Hint4, boost::optional<gtsam::Matrix&> H1,
-      boost::optional<gtsam::Matrix&> H2, boost::optional<gtsam::Matrix&> H3,
-      boost::optional<gtsam::Matrix&> H4) {
+      const gtsam::Matrix& Hint4, std::optional<gtsam::Matrix> H1,
+      std::optional<gtsam::Matrix> H2, std::optional<gtsam::Matrix> H3,
+      std::optional<gtsam::Matrix> H4) {
     if (H1) *H1 = Hpose * Hint1;
     if (H2) *H2 = Hpose * Hint2;
     if (H3) *H3 = Hpose * Hint3;
@@ -123,11 +122,10 @@ class GaussianProcessInterpolatorLie {
   gtsam::Vector interpolateVelocity(
       const T& pose1, const gtsam::Vector& vel1, const T& pose2,
       const gtsam::Vector& vel2,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 =
-          boost::none) const {
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 = {}) const {
     using namespace gtsam;
 
     const Vector r1 = (Vector(2 * dof_) << Vector::Zero(dof_), vel1).finished();

--- a/gpmp2/gp/GaussianProcessInterpolatorLinear.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLinear.h
@@ -10,6 +10,7 @@
 #include <gpmp2/gp/GPutils.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/OptionalJacobian.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 #include <boost/serialization/array.hpp>
 
@@ -81,12 +82,15 @@ class GaussianProcessInterpolatorLinear {
   }
 
   /// update jacobian based on interpolated jacobians
-  static void updatePoseJacobians(
-      const gtsam::Matrix& Hpose, const gtsam::Matrix& Hint1,
-      const gtsam::Matrix& Hint2, const gtsam::Matrix& Hint3,
-      const gtsam::Matrix& Hint4, std::optional<gtsam::Matrix> H1,
-      std::optional<gtsam::Matrix> H2, std::optional<gtsam::Matrix> H3,
-      std::optional<gtsam::Matrix> H4) {
+  static void updatePoseJacobians(const gtsam::Matrix& Hpose,
+                                  const gtsam::Matrix& Hint1,
+                                  const gtsam::Matrix& Hint2,
+                                  const gtsam::Matrix& Hint3,
+                                  const gtsam::Matrix& Hint4,
+                                  gtsam::OptionalMatrixType H1 = nullptr,
+                                  gtsam::OptionalMatrixType H2 = nullptr,
+                                  gtsam::OptionalMatrixType H3 = nullptr,
+                                  gtsam::OptionalMatrixType H4 = nullptr) {
     if (H1) *H1 = Hpose * Hint1;
     if (H2) *H2 = Hpose * Hint2;
     if (H3) *H3 = Hpose * Hint3;

--- a/gpmp2/gp/GaussianProcessInterpolatorLinear.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLinear.h
@@ -58,11 +58,10 @@ class GaussianProcessInterpolatorLinear {
   gtsam::Vector interpolatePose(
       const gtsam::Vector& pose1, const gtsam::Vector& vel1,
       const gtsam::Vector& pose2, const gtsam::Vector& vel2,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 =
-          boost::none) const {
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 = {}) const {
     using namespace gtsam;
 
     // state vector
@@ -85,9 +84,9 @@ class GaussianProcessInterpolatorLinear {
   static void updatePoseJacobians(
       const gtsam::Matrix& Hpose, const gtsam::Matrix& Hint1,
       const gtsam::Matrix& Hint2, const gtsam::Matrix& Hint3,
-      const gtsam::Matrix& Hint4, boost::optional<gtsam::Matrix&> H1,
-      boost::optional<gtsam::Matrix&> H2, boost::optional<gtsam::Matrix&> H3,
-      boost::optional<gtsam::Matrix&> H4) {
+      const gtsam::Matrix& Hint4, std::optional<gtsam::Matrix> H1,
+      std::optional<gtsam::Matrix> H2, std::optional<gtsam::Matrix> H3,
+      std::optional<gtsam::Matrix> H4) {
     if (H1) *H1 = Hpose * Hint1;
     if (H2) *H2 = Hpose * Hint2;
     if (H3) *H3 = Hpose * Hint3;
@@ -98,11 +97,10 @@ class GaussianProcessInterpolatorLinear {
   gtsam::Vector interpolateVelocity(
       const gtsam::Vector& pose1, const gtsam::Vector& vel1,
       const gtsam::Vector& pose2, const gtsam::Vector& vel2,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = boost::none,
-      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 =
-          boost::none) const {
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H1 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H2 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H3 = {},
+      gtsam::OptionalJacobian<Eigen::Dynamic, Eigen::Dynamic> H4 = {}) const {
     using namespace gtsam;
 
     // state vector

--- a/gpmp2/gp/GaussianProcessInterpolatorLinear.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLinear.h
@@ -12,7 +12,9 @@
 #include <gtsam/base/OptionalJacobian.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
 #include <boost/serialization/array.hpp>
+#endif
 
 namespace gpmp2 {
 
@@ -148,6 +150,7 @@ class GaussianProcessInterpolatorLinear {
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -160,6 +163,7 @@ class GaussianProcessInterpolatorLinear {
     ar& make_nvp("Lambda", make_array(Lambda_.data(), Lambda_.size()));
     ar& make_nvp("Psi", make_array(Psi_.data(), Psi_.size()));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/gp/GaussianProcessPriorLie.h
+++ b/gpmp2/gp/GaussianProcessPriorLie.h
@@ -13,8 +13,6 @@
 #include <gtsam/geometry/concepts.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/serialization/export.hpp>
 #include <ostream>
 
 namespace gpmp2 {
@@ -118,6 +116,7 @@ class GaussianProcessPriorLie
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -126,6 +125,7 @@ class GaussianProcessPriorLie
     ar& BOOST_SERIALIZATION_NVP(dof_);
     ar& BOOST_SERIALIZATION_NVP(delta_t_);
   }
+#endif
 
 };  // GaussianProcessPriorLie
 

--- a/gpmp2/gp/GaussianProcessPriorLie.h
+++ b/gpmp2/gp/GaussianProcessPriorLie.h
@@ -26,7 +26,7 @@ template <typename T>
 class GaussianProcessPriorLie
     : public gtsam::NoiseModelFactor4<T, gtsam::Vector, T, gtsam::Vector> {
  private:
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
   typedef GaussianProcessPriorLie<T> This;
   typedef gtsam::NoiseModelFactor4<T, gtsam::Vector, T, gtsam::Vector> Base;
 
@@ -52,18 +52,17 @@ class GaussianProcessPriorLie
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
   /// factor error function
-  gtsam::Vector evaluateError(
-      const T& pose1, const gtsam::Vector& vel1, const T& pose2,
-      const gtsam::Vector& vel2,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none,
-      boost::optional<gtsam::Matrix&> H3 = boost::none,
-      boost::optional<gtsam::Matrix&> H4 = boost::none) const {
+  gtsam::Vector evaluateError(const T& pose1, const gtsam::Vector& vel1,
+                              const T& pose2, const gtsam::Vector& vel2,
+                              std::optional<gtsam::Matrix> H1 = {},
+                              std::optional<gtsam::Matrix> H2 = {},
+                              std::optional<gtsam::Matrix> H3 = {},
+                              std::optional<gtsam::Matrix> H4 = {}) const {
     using namespace gtsam;
 
     Matrix Hinv, Hcomp1, Hcomp2, Hlogmap;

--- a/gpmp2/gp/GaussianProcessPriorLie.h
+++ b/gpmp2/gp/GaussianProcessPriorLie.h
@@ -24,11 +24,11 @@ namespace gpmp2 {
  */
 template <typename T>
 class GaussianProcessPriorLie
-    : public gtsam::NoiseModelFactor4<T, gtsam::Vector, T, gtsam::Vector> {
+    : public gtsam::NoiseModelFactorN<T, gtsam::Vector, T, gtsam::Vector> {
  private:
   GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
   typedef GaussianProcessPriorLie<T> This;
-  typedef gtsam::NoiseModelFactor4<T, gtsam::Vector, T, gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<T, gtsam::Vector, T, gtsam::Vector> Base;
 
   size_t dof_;
   double delta_t_;
@@ -48,21 +48,21 @@ class GaussianProcessPriorLie
         dof_(Qc_model->dim()),
         delta_t_(delta_t) {}
 
-  virtual ~GaussianProcessPriorLie() {}
+  ~GaussianProcessPriorLie() {}
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
   /// factor error function
-  gtsam::Vector evaluateError(const T& pose1, const gtsam::Vector& vel1,
-                              const T& pose2, const gtsam::Vector& vel2,
-                              std::optional<gtsam::Matrix> H1 = {},
-                              std::optional<gtsam::Matrix> H2 = {},
-                              std::optional<gtsam::Matrix> H3 = {},
-                              std::optional<gtsam::Matrix> H4 = {}) const {
+  gtsam::Vector evaluateError(
+      const T& pose1, const gtsam::Vector& vel1, const T& pose2,
+      const gtsam::Vector& vel2, gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr,
+      gtsam::OptionalMatrixType H4 = nullptr) const override {
     using namespace gtsam;
 
     Matrix Hinv, Hcomp1, Hcomp2, Hlogmap;
@@ -101,8 +101,8 @@ class GaussianProcessPriorLie
   size_t size() const { return 4; }
 
   /** equals specialized to this factor */
-  virtual bool equals(const gtsam::NonlinearFactor& expected,
-                      double tol = 1e-9) const {
+  bool equals(const gtsam::NonlinearFactor& expected,
+              double tol = 1e-9) const override {
     const This* e = dynamic_cast<const This*>(&expected);
     return e != NULL && Base::equals(*e, tol) &&
            fabs(this->delta_t_ - e->delta_t_) < tol;

--- a/gpmp2/gp/GaussianProcessPriorLinear.h
+++ b/gpmp2/gp/GaussianProcessPriorLinear.h
@@ -25,14 +25,14 @@ class GaussianProcessPriorLinear
   size_t dof_;
   double delta_t_;
 
+ public:
   typedef GaussianProcessPriorLinear This;
-  typedef gtsam::NoiseModelFactor4<gtsam::Vector, gtsam::Vector, gtsam::Vector,
+  typedef gtsam::NoiseModelFactorN<gtsam::Vector, gtsam::Vector, gtsam::Vector,
                                    gtsam::Vector>
       Base;
 
- public:
-  GaussianProcessPriorLinear() {
-  } /* Default constructor only for serialization */
+  /* Default constructor only for serialization */
+  GaussianProcessPriorLinear() {}
 
   /// Constructor
   /// @param delta_t is the time between the two states
@@ -50,18 +50,19 @@ class GaussianProcessPriorLinear
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 
   /// factor error function
-  gtsam::Vector evaluateError(
-      const gtsam::Vector& pose1, const gtsam::Vector& vel1,
-      const gtsam::Vector& pose2, const gtsam::Vector& vel2,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none,
-      boost::optional<gtsam::Matrix&> H3 = boost::none,
-      boost::optional<gtsam::Matrix&> H4 = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Vector& pose1,
+                              const gtsam::Vector& vel1,
+                              const gtsam::Vector& pose2,
+                              const gtsam::Vector& vel2,
+                              std::optional<gtsam::Matrix> H1 = {},
+                              std::optional<gtsam::Matrix> H2 = {},
+                              std::optional<gtsam::Matrix> H3 = {},
+                              std::optional<gtsam::Matrix> H4 = {}) const {
     // using namespace gtsam;
 
     // state vector

--- a/gpmp2/gp/GaussianProcessPriorLinear.h
+++ b/gpmp2/gp/GaussianProcessPriorLinear.h
@@ -11,9 +11,6 @@
 #include <gtsam/geometry/concepts.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/serialization/base_object.hpp>
-
 namespace gpmp2 {
 
 /**
@@ -119,6 +116,7 @@ class GaussianProcessPriorLinear
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -127,6 +125,7 @@ class GaussianProcessPriorLinear
     ar& BOOST_SERIALIZATION_NVP(dof_);
     ar& BOOST_SERIALIZATION_NVP(delta_t_);
   }
+#endif
 
 };  // GaussianProcessPriorLinear
 

--- a/gpmp2/gp/tests/testGaussianProcessInterpolatorLinear.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessInterpolatorLinear.cpp
@@ -64,24 +64,24 @@ TEST(GaussianProcessInterpolatorLinear, interpolatePose) {
                                 actualH4);
   expect = (Vector3() << 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector3(const Vector3&)>(std::bind(
           &GPBase::interpolatePose, base, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -98,24 +98,24 @@ TEST(GaussianProcessInterpolatorLinear, interpolatePose) {
                                 actualH4);
   expect = (Vector3() << 0.3, 0, 0).finished();
   expectH1 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector3(const Vector3&)>(std::bind(
           &GPBase::interpolatePose, base, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -132,24 +132,24 @@ TEST(GaussianProcessInterpolatorLinear, interpolatePose) {
                                 actualH4);
   expect = (Vector3() << 0, 0, 0.09).finished();
   expectH1 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector3(const Vector3&)>(std::bind(
           &GPBase::interpolatePose, base, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -165,24 +165,24 @@ TEST(GaussianProcessInterpolatorLinear, interpolatePose) {
   actual = base.interpolatePose(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expectH1 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector3(const Vector3&)>(std::bind(
           &GPBase::interpolatePose, base, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(std::bind(
-          &GPBase::interpolatePose, base, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(
+          std::bind(&GPBase::interpolatePose, base, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
   EXPECT(assert_equal(expectH2, actualH2, 1e-6));

--- a/gpmp2/gp/tests/testGaussianProcessInterpolatorPose2.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessInterpolatorPose2.cpp
@@ -38,26 +38,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose2(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Pose2(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -76,26 +73,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose2(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-4);
   expectH2 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-4);
   expectH3 = numericalDerivative11(
-      std::function<Pose2(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-4);
   expectH4 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-4);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -114,26 +108,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose2(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Pose2(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -151,26 +142,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose2(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Pose2(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Pose2(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose2(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
   EXPECT(assert_equal(expectH2, actualH2, 1e-8));
@@ -201,26 +189,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolateVelocity) {
   expectH1 = numericalDerivative11(
       std::function<Vector3(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector3(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -239,26 +224,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolateVelocity) {
   expectH1 = numericalDerivative11(
       std::function<Vector3(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-4);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-4);
   expectH3 = numericalDerivative11(
-      std::function<Vector3(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-4);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-4);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -277,26 +259,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolateVelocity) {
   expectH1 = numericalDerivative11(
       std::function<Vector3(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector3(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -314,26 +293,23 @@ TEST(GaussianProcessInterpolatorPose2, interpolateVelocity) {
   expectH1 = numericalDerivative11(
       std::function<Vector3(const Pose2&)>(
           std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector3(const Pose2&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Pose2&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector3(const Vector3&)>(
-          std::bind(&GaussianProcessInterpolatorPose2::interpolateVelocity,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Vector3(const Vector3&)>(std::bind(
+          &GaussianProcessInterpolatorPose2::interpolateVelocity, base, p1, v1,
+          p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
   EXPECT(assert_equal(expectH2, actualH2, 1e-8));

--- a/gpmp2/gp/tests/testGaussianProcessInterpolatorPose2Vector.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessInterpolatorPose2Vector.cpp
@@ -38,26 +38,23 @@ TEST(GaussianProcessInterpolatorPose2Vector, interpolatePose) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Pose2Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -76,26 +73,23 @@ TEST(GaussianProcessInterpolatorPose2Vector, interpolatePose) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Pose2Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-4));
@@ -114,26 +108,23 @@ TEST(GaussianProcessInterpolatorPose2Vector, interpolatePose) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Pose2Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -151,26 +142,23 @@ TEST(GaussianProcessInterpolatorPose2Vector, interpolatePose) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Pose2Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, std::placeholders::_1, v1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+                    base, std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, std::placeholders::_1, p2, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, std::placeholders::_1, v2, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Pose2Vector(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose2Vector::interpolatePose,
-                    base, p1, v1, p2, std::placeholders::_1, boost::none,
-                    boost::none, boost::none, boost::none)),
+      std::function<Pose2Vector(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose2Vector::interpolatePose, base, p1,
+          v1, p2, std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
   EXPECT(assert_equal(expectH2, actualH2, 1e-8));

--- a/gpmp2/gp/tests/testGaussianProcessInterpolatorPose3.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessInterpolatorPose3.cpp
@@ -38,26 +38,23 @@ TEST(GaussianProcessInterpolatorPose3, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose3(const Pose3&)>(
           std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Pose3(const Pose3&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Pose3&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -76,26 +73,23 @@ TEST(GaussianProcessInterpolatorPose3, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose3(const Pose3&)>(
           std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-4);
   expectH2 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-4);
   expectH3 = numericalDerivative11(
-      std::function<Pose3(const Pose3&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Pose3&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-4);
   expectH4 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-4);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -114,26 +108,23 @@ TEST(GaussianProcessInterpolatorPose3, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose3(const Pose3&)>(
           std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Pose3(const Pose3&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Pose3&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
@@ -151,26 +142,23 @@ TEST(GaussianProcessInterpolatorPose3, interpolatePose) {
   expectH1 = numericalDerivative11(
       std::function<Pose3(const Pose3&)>(
           std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Pose3(const Pose3&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Pose3&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Pose3(const Vector6&)>(
-          std::bind(&GaussianProcessInterpolatorPose3::interpolatePose, base,
-                    p1, v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Pose3(const Vector6&)>(std::bind(
+          &GaussianProcessInterpolatorPose3::interpolatePose, base, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-8));
   EXPECT(assert_equal(expectH2, actualH2, 1e-8));

--- a/gpmp2/gp/tests/testGaussianProcessPriorLinear.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorLinear.cpp
@@ -42,8 +42,8 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
   p2 = (Vector(3) << 0, 0, 0).finished();
   v1 = (Vector(3) << 0, 0, 0).finished();
   v2 = (Vector(3) << 0, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(
@@ -76,8 +76,8 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
   p2 = (Vector3() << 0.1, 0, 0).finished();
   v1 = (Vector3() << 1, 0, 0).finished();
   v2 = (Vector3() << 1, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(
@@ -110,8 +110,8 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
   p2 = (Vector3() << 0, 0, 0.1).finished();
   v1 = (Vector3() << 0, 0, 1).finished();
   v2 = (Vector3() << 0, 0, 1).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(
@@ -144,8 +144,8 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
   p2 = (Vector3() << -8, 4, -8).finished();
   v1 = (Vector3() << -1, 2, -9).finished();
   v2 = (Vector3() << 3, -4, 7).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expectH1 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(
           std::bind(&GPPrior::evaluateError, factor, std::placeholders::_1, v1,

--- a/gpmp2/gp/tests/testGaussianProcessPriorLinear.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorLinear.cpp
@@ -46,24 +46,24 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
                                 actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(std::bind(
           &GPPrior::evaluateError, factor, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -80,24 +80,24 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
                                 actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(std::bind(
           &GPPrior::evaluateError, factor, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -114,24 +114,24 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
                                 actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(std::bind(
           &GPPrior::evaluateError, factor, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -147,24 +147,24 @@ TEST_UNSAFE(GaussianProcessPriorLinear, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expectH1 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, std::placeholders::_1, v1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, std::placeholders::_1, v1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, std::placeholders::_1, p2, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, std::placeholders::_1,
+                    p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
       std::function<Vector(const Vector3&)>(std::bind(
           &GPPrior::evaluateError, factor, p1, v1, std::placeholders::_1, v2,
-          boost::none, boost::none, boost::none, boost::none)),
+          nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(std::bind(
-          &GPPrior::evaluateError, factor, p1, v1, p2, std::placeholders::_1,
-          boost::none, boost::none, boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(
+          std::bind(&GPPrior::evaluateError, factor, p1, v1, p2,
+                    std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
   EXPECT(assert_equal(expectH2, actualH2, 1e-6));

--- a/gpmp2/gp/tests/testGaussianProcessPriorPose2.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorPose2.cpp
@@ -41,8 +41,8 @@ TEST(GaussianProcessPriorPose2, Factor) {
   p2 = Pose2(0, 0, 0);
   v1 = (Vector3() << 0, 0, 0).finished();
   v2 = (Vector3() << 0, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
@@ -76,8 +76,8 @@ TEST(GaussianProcessPriorPose2, Factor) {
   p2 = Pose2(0.1, 0, 0);
   v1 = (Vector3() << 1, 0, 0).finished();
   v2 = (Vector3() << 1, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
@@ -111,8 +111,8 @@ TEST(GaussianProcessPriorPose2, Factor) {
   p2 = Pose2(0, 0, 0.1);
   v1 = (Vector3() << 0, 0, 1).finished();
   v2 = (Vector3() << 0, 0, 1).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
@@ -146,8 +146,8 @@ TEST(GaussianProcessPriorPose2, Factor) {
   p2 = Pose2(2.4, -2.5, 3.7);
   v1 = (Vector3() << 5, 4, 9).finished();
   v2 = (Vector3() << 0, 6, 4).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
                                 &GaussianProcessPriorPose2::evaluateError,

--- a/gpmp2/gp/tests/testGaussianProcessPriorPose2.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorPose2.cpp
@@ -44,29 +44,26 @@ TEST(GaussianProcessPriorPose2, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
+                                &GaussianProcessPriorPose2::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -82,29 +79,26 @@ TEST(GaussianProcessPriorPose2, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-4);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
+                                &GaussianProcessPriorPose2::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-4);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-4);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-4);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-4);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -120,29 +114,26 @@ TEST(GaussianProcessPriorPose2, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expect = (Vector(6) << 0, 0, 0, 0, 0, 0).finished();
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
+                                &GaussianProcessPriorPose2::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -157,29 +148,26 @@ TEST(GaussianProcessPriorPose2, Factor) {
   v2 = (Vector3() << 0, 6, 4).finished();
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose2&)>(std::bind(
+                                &GaussianProcessPriorPose2::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose2&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector3&)>(
-          std::bind(&GaussianProcessPriorPose2::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector3&)>(std::bind(
+          &GaussianProcessPriorPose2::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
   EXPECT(assert_equal(expectH2, actualH2, 1e-6));

--- a/gpmp2/gp/tests/testGaussianProcessPriorPose2Vector.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorPose2Vector.cpp
@@ -47,26 +47,23 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -85,26 +82,23 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-4));
@@ -123,26 +117,23 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -160,26 +151,23 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+                    std::placeholders::_1, v1, p2, v2, nullptr, nullptr,
+                    nullptr, nullptr)),
       p1, 1e-6);
   expectH2 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivativeDynamic(
-      std::function<Vector(const Pose2Vector&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose2Vector&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivativeDynamic(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor, p1,
-                    v1, p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose2Vector::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
   EXPECT(assert_equal(expectH2, actualH2, 1e-6));

--- a/gpmp2/gp/tests/testGaussianProcessPriorPose2Vector.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorPose2Vector.cpp
@@ -41,8 +41,8 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   p2 = Pose2Vector(Pose2(0, 0, 0), Vector3(0, 0, 0));
   v1 = (Vector6() << 0, 0, 0, 0, 0, 0).finished();
   v2 = (Vector6() << 0, 0, 0, 0, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
@@ -76,8 +76,8 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   p2 = Pose2Vector(Pose2(0.1, 0, 0), Vector3(0, 0.2, 0));
   v1 = (Vector6() << 1, 0, 0, 0, 2, 0).finished();
   v2 = (Vector6() << 1, 0, 0, 0, 2, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
@@ -111,8 +111,8 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   p2 = Pose2Vector(Pose2(0, 0, 0.1), Vector3(0, 0, 0));
   v1 = (Vector6() << 0, 0, 1, 0, 0, 0).finished();
   v2 = (Vector6() << 0, 0, 1, 0, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
@@ -146,8 +146,8 @@ TEST(GaussianProcessPriorPose2Vector, Factor) {
   p2 = Pose2Vector(Pose2(-9, 3, 4), Vector3(-6, -0.2, 0.8));
   v1 = (Vector6() << 0.5, 0.9, 0.7, 3, -8, 2).finished();
   v2 = (Vector6() << 0.6, -0.2, 0.8, -9, 3, 4).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expectH1 = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&GaussianProcessPriorPose2Vector::evaluateError, factor,

--- a/gpmp2/gp/tests/testGaussianProcessPriorPose3.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorPose3.cpp
@@ -44,29 +44,26 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
+                                &GaussianProcessPriorPose3::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose3&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -82,29 +79,26 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
+                                &GaussianProcessPriorPose3::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose3&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -120,29 +114,26 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
+                                &GaussianProcessPriorPose3::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose3&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(expectH1, actualH1, 1e-6));
@@ -157,29 +148,26 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   v2 = (Vector6() << 1, 3, 8, 0, 6, 4).finished();
   actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
                                 actualH4);
-  expectH1 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor,
-                    std::placeholders::_1, v1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
-      p1, 1e-6);
+  expectH1 =
+      numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
+                                &GaussianProcessPriorPose3::evaluateError,
+                                factor, std::placeholders::_1, v1, p2, v2,
+                                nullptr, nullptr, nullptr, nullptr)),
+                            p1, 1e-6);
   expectH2 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1,
-                    std::placeholders::_1, p2, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1,
+          std::placeholders::_1, p2, v2, nullptr, nullptr, nullptr, nullptr)),
       v1, 1e-6);
   expectH3 = numericalDerivative11(
-      std::function<Vector(const Pose3&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    std::placeholders::_1, v2, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Pose3&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
+          std::placeholders::_1, v2, nullptr, nullptr, nullptr, nullptr)),
       p2, 1e-6);
   expectH4 = numericalDerivative11(
-      std::function<Vector(const Vector6&)>(
-          std::bind(&GaussianProcessPriorPose3::evaluateError, factor, p1, v1,
-                    p2, std::placeholders::_1, boost::none, boost::none,
-                    boost::none, boost::none)),
+      std::function<Vector(const Vector6&)>(std::bind(
+          &GaussianProcessPriorPose3::evaluateError, factor, p1, v1, p2,
+          std::placeholders::_1, nullptr, nullptr, nullptr, nullptr)),
       v2, 1e-6);
   EXPECT(assert_equal(expectH1, actualH1, 1e-5));
   EXPECT(assert_equal(expectH2, actualH2, 1e-6));

--- a/gpmp2/gp/tests/testGaussianProcessPriorPose3.cpp
+++ b/gpmp2/gp/tests/testGaussianProcessPriorPose3.cpp
@@ -41,8 +41,8 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   p2 = Pose3(Rot3::Ypr(0.0, 0.0, 0.0), Point3(0.0, 0.0, 0.0));
   v1 = (Vector6() << 0, 0, 0, 0, 0, 0).finished();
   v2 = (Vector6() << 0, 0, 0, 0, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
@@ -76,8 +76,8 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   p2 = Pose3(Rot3::Ypr(0.0, 0.0, 0.0), Point3(0.1, 0.0, 0.0));
   v1 = (Vector6() << 0, 0, 0, 1, 0, 0).finished();
   v2 = (Vector6() << 0, 0, 0, 1, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
@@ -111,8 +111,8 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   p2 = Pose3(Rot3::Ypr(0.1, 0.0, 0.0), Point3(0.0, 0.0, 0.0));
   v1 = (Vector6() << 0, 0, 1, 0, 0, 0).finished();
   v2 = (Vector6() << 0, 0, 1, 0, 0, 0).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expect = (Vector(12) << 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0).finished();
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
@@ -146,8 +146,8 @@ TEST(GaussianProcessPriorPose3Test, Factor) {
   p2 = Pose3(Rot3::Ypr(2.4, -2.5, 3.7), Point3(9.0, -8.0, -7.0));
   v1 = (Vector6() << 2, 3, 1, 5, 4, 9).finished();
   v2 = (Vector6() << 1, 3, 8, 0, 6, 4).finished();
-  actual = factor.evaluateError(p1, v1, p2, v2, actualH1, actualH2, actualH3,
-                                actualH4);
+  actual = factor.evaluateError(p1, v1, p2, v2, &actualH1, &actualH2, &actualH3,
+                                &actualH4);
   expectH1 =
       numericalDerivative11(std::function<Vector(const Pose3&)>(std::bind(
                                 &GaussianProcessPriorPose3::evaluateError,

--- a/gpmp2/kinematics/Arm.cpp
+++ b/gpmp2/kinematics/Arm.cpp
@@ -29,12 +29,13 @@ Arm::Arm(size_t dof, const Vector& a, const Vector& alpha, const Vector& d,
 }
 
 /* ************************************************************************** */
-void Arm::forwardKinematics(const Vector& jp, std::optional<const Vector> jv,
-                            std::vector<gtsam::Pose3>& jpx,
-                            std::optional<std::vector<gtsam::Vector3>> jvx,
-                            std::optional<std::vector<Matrix>> J_jpx_jp,
-                            std::optional<std::vector<Matrix>> J_jvx_jp,
-                            std::optional<std::vector<Matrix>> J_jvx_jv) const {
+void Arm::forwardKinematics(
+    const Vector& jp, std::optional<const Vector> jv,
+    std::vector<gtsam::Pose3>& jpx,
+    std::vector<gtsam::Vector3>* jvx,
+    gtsam::OptionalMatrixVecType J_jpx_jp,
+    gtsam::OptionalMatrixVecType J_jvx_jp,
+    gtsam::OptionalMatrixVecType J_jvx_jv) const {
   using namespace std;
 
   // space for output
@@ -82,13 +83,17 @@ void Arm::forwardKinematics(const Vector& jp, std::optional<const Vector> jv,
   // cache dHoi_dqj (DOF^2 memory), only fill in i >= j since others are all
   // zeros
   vector<vector<Matrix4>> dHo_dq(dof(), vector<Matrix4>(dof()));
-  if (J_jpx_jp || J_jvx_jp)
-    for (size_t i = 0; i < dof(); i++)
-      for (size_t j = 0; j <= i; j++)
-        if (i > j)
+  if (J_jpx_jp || J_jvx_jp) {
+    for (size_t i = 0; i < dof(); i++) {
+      for (size_t j = 0; j <= i; j++) {
+        if (i > j) {
           dHo_dq[i][j] = Ho[j] * dH[j] * Hoinv[j + 1] * Ho[i + 1];
-        else
+        } else {
           dHo_dq[i][j] = Ho[j] * dH[j];
+        }
+      }
+    }
+  }
 
   // start calculating Forward and velocity kinematics / Jacobians
   for (size_t i = 0; i < dof(); i++) {

--- a/gpmp2/kinematics/Arm.cpp
+++ b/gpmp2/kinematics/Arm.cpp
@@ -29,13 +29,12 @@ Arm::Arm(size_t dof, const Vector& a, const Vector& alpha, const Vector& d,
 }
 
 /* ************************************************************************** */
-void Arm::forwardKinematics(
-    const Vector& jp, boost::optional<const Vector&> jv,
-    std::vector<gtsam::Pose3>& jpx,
-    boost::optional<std::vector<gtsam::Vector3>&> jvx,
-    boost::optional<std::vector<Matrix>&> J_jpx_jp,
-    boost::optional<std::vector<Matrix>&> J_jvx_jp,
-    boost::optional<std::vector<Matrix>&> J_jvx_jv) const {
+void Arm::forwardKinematics(const Vector& jp, std::optional<const Vector> jv,
+                            std::vector<gtsam::Pose3>& jpx,
+                            std::optional<std::vector<gtsam::Vector3>> jvx,
+                            std::optional<std::vector<Matrix>> J_jpx_jp,
+                            std::optional<std::vector<Matrix>> J_jvx_jp,
+                            std::optional<std::vector<Matrix>> J_jvx_jv) const {
   using namespace std;
 
   // space for output
@@ -82,7 +81,7 @@ void Arm::forwardKinematics(
 
   // cache dHoi_dqj (DOF^2 memory), only fill in i >= j since others are all
   // zeros
-  vector<vector<Matrix4> > dHo_dq(dof(), vector<Matrix4>(dof()));
+  vector<vector<Matrix4>> dHo_dq(dof(), vector<Matrix4>(dof()));
   if (J_jpx_jp || J_jvx_jp)
     for (size_t i = 0; i < dof(); i++)
       for (size_t j = 0; j <= i; j++)

--- a/gpmp2/kinematics/Arm.h
+++ b/gpmp2/kinematics/Arm.h
@@ -74,13 +74,12 @@ class GPMP2_EXPORT Arm
    *  @param J_jpx_jp et al. optional Jacobians
    **/
   void forwardKinematics(
-      const gtsam::Vector& jp, boost::optional<const gtsam::Vector&> jv,
+      const gtsam::Vector& jp, std::optional<const gtsam::Vector> jv,
       std::vector<gtsam::Pose3>& jpx,
-      boost::optional<std::vector<gtsam::Vector3>&> jvx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jpx_jp = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jvx_jp = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jvx_jv =
-          boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> jvx,
+      std::optional<std::vector<gtsam::Matrix>> J_jpx_jp = {},
+      std::optional<std::vector<gtsam::Matrix>> J_jvx_jp = {},
+      std::optional<std::vector<gtsam::Matrix>> J_jvx_jv = {}) const;
 
   /// update base pose in const
   void updateBasePose(const gtsam::Pose3& p) const { base_pose_ = p; }

--- a/gpmp2/kinematics/Arm.h
+++ b/gpmp2/kinematics/Arm.h
@@ -73,13 +73,13 @@ class GPMP2_EXPORT Arm
    *  @param jvx joint velocity in work space
    *  @param J_jpx_jp et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const gtsam::Vector& jp, std::optional<const gtsam::Vector> jv,
-      std::vector<gtsam::Pose3>& jpx,
-      std::optional<std::vector<gtsam::Vector3>> jvx,
-      std::optional<std::vector<gtsam::Matrix>> J_jpx_jp = {},
-      std::optional<std::vector<gtsam::Matrix>> J_jvx_jp = {},
-      std::optional<std::vector<gtsam::Matrix>> J_jvx_jv = {}) const;
+  void forwardKinematics(const gtsam::Vector& jp,
+                         std::optional<const gtsam::Vector> jv,
+                         std::vector<gtsam::Pose3>& jpx,
+                         std::vector<gtsam::Vector3>* jvx = nullptr,
+                         gtsam::OptionalMatrixVecType J_jpx_jp = nullptr,
+                         gtsam::OptionalMatrixVecType J_jvx_jp = nullptr,
+                         gtsam::OptionalMatrixVecType J_jvx_jv = nullptr) const;
 
   /// update base pose in const
   void updateBasePose(const gtsam::Pose3& p) const { base_pose_ = p; }

--- a/gpmp2/kinematics/ForwardKinematics-inl.h
+++ b/gpmp2/kinematics/ForwardKinematics-inl.h
@@ -14,7 +14,7 @@ template <class POSE, class VELOCITY>
 gtsam::Matrix ForwardKinematics<POSE, VELOCITY>::forwardKinematicsPose(
     const Pose& jp) const {
   std::vector<gtsam::Pose3> jpx;
-  forwardKinematics(jp, boost::none, jpx, boost::none);
+  forwardKinematics(jp, {}, jpx, {});
 
   // convert vector in matrix
   gtsam::Matrix jpx_mat(6, nr_links_);
@@ -32,7 +32,7 @@ template <class POSE, class VELOCITY>
 gtsam::Matrix ForwardKinematics<POSE, VELOCITY>::forwardKinematicsPosition(
     const Pose& jp) const {
   std::vector<gtsam::Pose3> jpx;
-  forwardKinematics(jp, boost::none, jpx, boost::none);
+  forwardKinematics(jp, {}, jpx, {});
 
   // convert vector in matrix
   gtsam::Matrix jpx_mat(3, nr_links_);

--- a/gpmp2/kinematics/ForwardKinematics-inl.h
+++ b/gpmp2/kinematics/ForwardKinematics-inl.h
@@ -14,7 +14,7 @@ template <class POSE, class VELOCITY>
 gtsam::Matrix ForwardKinematics<POSE, VELOCITY>::forwardKinematicsPose(
     const Pose& jp) const {
   std::vector<gtsam::Pose3> jpx;
-  forwardKinematics(jp, {}, jpx, {});
+  forwardKinematics(jp, {}, jpx, nullptr);
 
   // convert vector in matrix
   gtsam::Matrix jpx_mat(6, nr_links_);
@@ -32,7 +32,7 @@ template <class POSE, class VELOCITY>
 gtsam::Matrix ForwardKinematics<POSE, VELOCITY>::forwardKinematicsPosition(
     const Pose& jp) const {
   std::vector<gtsam::Pose3> jpx;
-  forwardKinematics(jp, {}, jpx, {});
+  forwardKinematics(jp, {}, jpx, nullptr);
 
   // convert vector in matrix
   gtsam::Matrix jpx_mat(3, nr_links_);
@@ -46,7 +46,7 @@ gtsam::Matrix ForwardKinematics<POSE, VELOCITY>::forwardKinematicsVel(
     const Pose& jp, const Velocity& jv) const {
   std::vector<gtsam::Pose3> jpx;
   std::vector<gtsam::Vector3> jvx;
-  forwardKinematics(jp, jv, jpx, jvx);
+  forwardKinematics(jp, jv, jpx, &jvx);
 
   // convert vector in matrix
   gtsam::Matrix jpv_mat(3, nr_links_);

--- a/gpmp2/kinematics/ForwardKinematics.h
+++ b/gpmp2/kinematics/ForwardKinematics.h
@@ -54,13 +54,12 @@ class ForwardKinematics {
    *  @param J_jpx_jp et al. optional Jacobians
    **/
   virtual void forwardKinematics(
-      const Pose& jp, boost::optional<const Velocity&> jv,
+      const Pose& jp, std::optional<const Velocity> jv,
       std::vector<gtsam::Pose3>& jpx,
-      boost::optional<std::vector<gtsam::Vector3>&> jvx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jpx_jp = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jvx_jp = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jvx_jv =
-          boost::none) const = 0;
+      std::optional<std::vector<gtsam::Vector3>> jvx,
+      std::optional<std::vector<gtsam::Matrix>> J_jpx_jp = {},
+      std::optional<std::vector<gtsam::Matrix>> J_jvx_jp = {},
+      std::optional<std::vector<gtsam::Matrix>> J_jvx_jv = {}) const = 0;
 
   /**
    * Matrix wrapper for forwardKinematics, mainly used by matlab

--- a/gpmp2/kinematics/ForwardKinematics.h
+++ b/gpmp2/kinematics/ForwardKinematics.h
@@ -10,6 +10,7 @@
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Vector.h>
 #include <gtsam/geometry/Pose3.h>
+#include <gtsam/nonlinear/NonlinearFactor.h>
 
 #include <vector>
 
@@ -56,10 +57,10 @@ class ForwardKinematics {
   virtual void forwardKinematics(
       const Pose& jp, std::optional<const Velocity> jv,
       std::vector<gtsam::Pose3>& jpx,
-      std::optional<std::vector<gtsam::Vector3>> jvx,
-      std::optional<std::vector<gtsam::Matrix>> J_jpx_jp = {},
-      std::optional<std::vector<gtsam::Matrix>> J_jvx_jp = {},
-      std::optional<std::vector<gtsam::Matrix>> J_jvx_jv = {}) const = 0;
+      std::vector<gtsam::Vector3>* jvx = nullptr,
+      gtsam::OptionalMatrixVecType J_jpx_jp = nullptr,
+      gtsam::OptionalMatrixVecType J_jvx_jp = nullptr,
+      gtsam::OptionalMatrixVecType J_jvx_jv = nullptr) const = 0;
 
   /**
    * Matrix wrapper for forwardKinematics, mainly used by matlab

--- a/gpmp2/kinematics/GaussianPriorWorkspaceOrientation.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspaceOrientation.h
@@ -59,7 +59,8 @@ class GaussianPriorWorkspaceOrientation
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, nullptr, &J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, nullptr,
+                                        &J_jpx_jp);
 
     if (H1) {
       Matrix36 H_rp;
@@ -90,12 +91,14 @@ class GaussianPriorWorkspaceOrientation
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int version) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/GaussianPriorWorkspaceOrientation.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspaceOrientation.h
@@ -21,7 +21,7 @@ namespace gpmp2 {
  */
 template <class ROBOT>
 class GaussianPriorWorkspaceOrientation
-    : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
+    : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
  public:
   // typedefs
   typedef ROBOT Robot;
@@ -30,7 +30,7 @@ class GaussianPriorWorkspaceOrientation
  private:
   // typedefs
   typedef GaussianPriorWorkspaceOrientation This;
-  typedef gtsam::NoiseModelFactor1<Pose> Base;
+  typedef gtsam::NoiseModelFactorN<Pose> Base;
 
   const Robot& robot_;           // Robot
   int joint_;                    // joint on the robot to be constrained
@@ -50,16 +50,16 @@ class GaussianPriorWorkspaceOrientation
         joint_(joint),
         des_orientation_(des_orientation) {}
 
-  virtual ~GaussianPriorWorkspaceOrientation() {}
+  ~GaussianPriorWorkspaceOrientation() {}
 
   /// factor error function
-  gtsam::Vector evaluateError(const Pose& pose,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const Pose& pose, gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, nullptr, &J_jpx_jp);
 
     if (H1) {
       Matrix36 H_rp;
@@ -74,7 +74,7 @@ class GaussianPriorWorkspaceOrientation
   }
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/kinematics/GaussianPriorWorkspaceOrientation.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspaceOrientation.h
@@ -53,22 +53,19 @@ class GaussianPriorWorkspaceOrientation
   virtual ~GaussianPriorWorkspaceOrientation() {}
 
   /// factor error function
-  gtsam::Vector evaluateError(
-      const Pose& pose,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const Pose& pose,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, boost::none, joint_pos,
-                                        boost::none, J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, J_jpx_jp);
 
     if (H1) {
       Matrix36 H_rp;
       Matrix33 H_er;
       Rot3 curr_orientation = joint_pos[joint_].rotation(H_rp);
-      Vector error =
-          des_orientation_.logmap(curr_orientation, boost::none, H_er);
+      Vector error = des_orientation_.logmap(curr_orientation, {}, H_er);
       *H1 = H_er * H_rp * J_jpx_jp[joint_];
       return error;
     } else {
@@ -78,7 +75,7 @@ class GaussianPriorWorkspaceOrientation
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/GaussianPriorWorkspacePose.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspacePose.h
@@ -87,12 +87,14 @@ class GaussianPriorWorkspacePose
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int version) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/GaussianPriorWorkspacePose.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspacePose.h
@@ -21,7 +21,7 @@ namespace gpmp2 {
  */
 template <class ROBOT>
 class GaussianPriorWorkspacePose
-    : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
+    : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
  public:
   // typedefs
   typedef ROBOT Robot;
@@ -30,7 +30,7 @@ class GaussianPriorWorkspacePose
  private:
   // typedefs
   typedef GaussianPriorWorkspacePose This;
-  typedef gtsam::NoiseModelFactor1<Pose> Base;
+  typedef gtsam::NoiseModelFactorN<Pose> Base;
 
   const Robot& robot_;     // Robot
   int joint_;              // joint on the robot to be constrained
@@ -52,13 +52,13 @@ class GaussianPriorWorkspacePose
   virtual ~GaussianPriorWorkspacePose() {}
 
   /// factor error function
-  gtsam::Vector evaluateError(const Pose& pose,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const Pose& pose, gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, &J_jpx_jp);
 
     if (H1) {
       Matrix66 H_ep;

--- a/gpmp2/kinematics/GaussianPriorWorkspacePose.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspacePose.h
@@ -52,19 +52,17 @@ class GaussianPriorWorkspacePose
   virtual ~GaussianPriorWorkspacePose() {}
 
   /// factor error function
-  gtsam::Vector evaluateError(
-      const Pose& pose,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const Pose& pose,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, boost::none, joint_pos,
-                                        boost::none, J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, J_jpx_jp);
 
     if (H1) {
       Matrix66 H_ep;
-      Vector error = des_pose_.logmap(joint_pos[joint_], boost::none, H_ep);
+      Vector error = des_pose_.logmap(joint_pos[joint_], {}, H_ep);
       *H1 = H_ep * J_jpx_jp[joint_];
       return error;
     } else {
@@ -74,7 +72,7 @@ class GaussianPriorWorkspacePose
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/GaussianPriorWorkspacePosition.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspacePosition.h
@@ -21,7 +21,7 @@ namespace gpmp2 {
  */
 template <class ROBOT>
 class GaussianPriorWorkspacePosition
-    : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
+    : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
  public:
   // typedefs
   typedef ROBOT Robot;
@@ -30,7 +30,7 @@ class GaussianPriorWorkspacePosition
  private:
   // typedefs
   typedef GaussianPriorWorkspacePosition This;
-  typedef gtsam::NoiseModelFactor1<Pose> Base;
+  typedef gtsam::NoiseModelFactorN<Pose> Base;
 
   const Robot& robot_;          // Robot
   int joint_;                   // joint on the robot to be constrained
@@ -49,16 +49,16 @@ class GaussianPriorWorkspacePosition
         joint_(joint),
         des_position_(des_position) {}
 
-  virtual ~GaussianPriorWorkspacePosition() {}
+  ~GaussianPriorWorkspacePosition() {}
 
   /// factor error function
-  gtsam::Vector evaluateError(const Pose& pose,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const Pose& pose, gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, &J_jpx_jp);
 
     if (H1) {
       Matrix36 Hpp;
@@ -71,7 +71,7 @@ class GaussianPriorWorkspacePosition
   }
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/kinematics/GaussianPriorWorkspacePosition.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspacePosition.h
@@ -88,12 +88,14 @@ class GaussianPriorWorkspacePosition
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
   void serialize(ARCHIVE& ar, const unsigned int version) {
     ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Base);
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/GaussianPriorWorkspacePosition.h
+++ b/gpmp2/kinematics/GaussianPriorWorkspacePosition.h
@@ -52,15 +52,13 @@ class GaussianPriorWorkspacePosition
   virtual ~GaussianPriorWorkspacePosition() {}
 
   /// factor error function
-  gtsam::Vector evaluateError(
-      const Pose& pose,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const Pose& pose,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
 
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    robot_.fk_model().forwardKinematics(pose, boost::none, joint_pos,
-                                        boost::none, J_jpx_jp);
+    robot_.fk_model().forwardKinematics(pose, {}, joint_pos, {}, J_jpx_jp);
 
     if (H1) {
       Matrix36 Hpp;
@@ -74,7 +72,7 @@ class GaussianPriorWorkspacePosition
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/GoalFactorArm.h
+++ b/gpmp2/kinematics/GoalFactorArm.h
@@ -88,6 +88,7 @@ class GoalFactorArm : public gtsam::NoiseModelFactorN<gtsam::Vector> {
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -95,6 +96,7 @@ class GoalFactorArm : public gtsam::NoiseModelFactorN<gtsam::Vector> {
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/GoalFactorArm.h
+++ b/gpmp2/kinematics/GoalFactorArm.h
@@ -21,11 +21,11 @@ namespace gpmp2 {
 /**
  * unary factor connect to the last pose in arm configuration space
  */
-class GoalFactorArm : public gtsam::NoiseModelFactor1<gtsam::Vector> {
+class GoalFactorArm : public gtsam::NoiseModelFactorN<gtsam::Vector> {
  private:
   // typedefs
   typedef GoalFactorArm This;
-  typedef gtsam::NoiseModelFactor1<gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<gtsam::Vector> Base;
 
   // arm
   Arm arm_;
@@ -48,17 +48,18 @@ class GoalFactorArm : public gtsam::NoiseModelFactor1<gtsam::Vector> {
                 const Arm& arm, const gtsam::Point3& dest_point)
       : Base(cost_model, poseKey), arm_(arm), dest_point_(dest_point) {}
 
-  virtual ~GoalFactorArm() {}
+  ~GoalFactorArm() {}
 
   /// error function
-  gtsam::Vector evaluateError(const gtsam::Vector& conf,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const gtsam::Vector& conf,
+      gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
 
     // fk
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    arm_.forwardKinematics(conf, {}, joint_pos, {}, J_jpx_jp);
+    arm_.forwardKinematics(conf, {}, joint_pos, {}, &J_jpx_jp);
 
     if (H1) {
       Matrix36 Hpp;
@@ -72,7 +73,7 @@ class GoalFactorArm : public gtsam::NoiseModelFactor1<gtsam::Vector> {
   }
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/kinematics/GoalFactorArm.h
+++ b/gpmp2/kinematics/GoalFactorArm.h
@@ -35,7 +35,7 @@ class GoalFactorArm : public gtsam::NoiseModelFactor1<gtsam::Vector> {
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /// Default constructor
   GoalFactorArm() {}
@@ -51,15 +51,14 @@ class GoalFactorArm : public gtsam::NoiseModelFactor1<gtsam::Vector> {
   virtual ~GoalFactorArm() {}
 
   /// error function
-  gtsam::Vector evaluateError(
-      const gtsam::Vector& conf,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Vector& conf,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
 
     // fk
     std::vector<Pose3> joint_pos;
     std::vector<Matrix> J_jpx_jp;
-    arm_.forwardKinematics(conf, boost::none, joint_pos, boost::none, J_jpx_jp);
+    arm_.forwardKinematics(conf, {}, joint_pos, {}, J_jpx_jp);
 
     if (H1) {
       Matrix36 Hpp;
@@ -74,7 +73,7 @@ class GoalFactorArm : public gtsam::NoiseModelFactor1<gtsam::Vector> {
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/JointLimitCost.h
+++ b/gpmp2/kinematics/JointLimitCost.h
@@ -7,14 +7,14 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace gpmp2 {
 
 /// hinge loss joint limit cost function
 inline double hingeLossJointLimitCost(double p, double down_limit,
                                       double up_limit, double thresh,
-                                      std::optional<double> H_p = {}) {
+                                      double* H_p = nullptr) {
   if (p < down_limit + thresh) {
     if (H_p) *H_p = -1.0;
     return down_limit + thresh - p;

--- a/gpmp2/kinematics/JointLimitCost.h
+++ b/gpmp2/kinematics/JointLimitCost.h
@@ -12,9 +12,9 @@
 namespace gpmp2 {
 
 /// hinge loss joint limit cost function
-inline double hingeLossJointLimitCost(
-    double p, double down_limit, double up_limit, double thresh,
-    boost::optional<double&> H_p = boost::none) {
+inline double hingeLossJointLimitCost(double p, double down_limit,
+                                      double up_limit, double thresh,
+                                      std::optional<double> H_p = {}) {
   if (p < down_limit + thresh) {
     if (H_p) *H_p = -1.0;
     return down_limit + thresh - p;

--- a/gpmp2/kinematics/JointLimitFactorPose2Vector.h
+++ b/gpmp2/kinematics/JointLimitFactorPose2Vector.h
@@ -41,7 +41,7 @@ class JointLimitFactorPose2Vector
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /**
    * Constructor, all limit vector dim = cost_model.dim = pose.configuration.dof
@@ -68,9 +68,8 @@ class JointLimitFactorPose2Vector
   virtual ~JointLimitFactorPose2Vector() {}
 
   /// error function
-  gtsam::Vector evaluateError(
-      const gpmp2::Pose2Vector& pose,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const gpmp2::Pose2Vector& pose,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
     // get configuration
     const gtsam::Vector& conf = pose.configuration();
@@ -97,7 +96,7 @@ class JointLimitFactorPose2Vector
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/JointLimitFactorPose2Vector.h
+++ b/gpmp2/kinematics/JointLimitFactorPose2Vector.h
@@ -82,9 +82,9 @@ class JointLimitFactorPose2Vector
     for (size_t i = 0; i < (size_t)conf.size(); i++) {
       if (H1) {
         double Hp;
-        err(i + 3) =
-            hingeLossJointLimitCost(conf(i), down_limit_(i + 3),
-                                    up_limit_(i + 3), limit_thresh_(i + 3), &Hp);
+        err(i + 3) = hingeLossJointLimitCost(conf(i), down_limit_(i + 3),
+                                             up_limit_(i + 3),
+                                             limit_thresh_(i + 3), &Hp);
         (*H1)(i + 3, i + 3) = Hp;
       } else {
         err(i + 3) =
@@ -111,6 +111,7 @@ class JointLimitFactorPose2Vector
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -118,6 +119,7 @@ class JointLimitFactorPose2Vector
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/JointLimitFactorPose2Vector.h
+++ b/gpmp2/kinematics/JointLimitFactorPose2Vector.h
@@ -27,11 +27,11 @@ namespace gpmp2 {
  * will be used
  */
 class JointLimitFactorPose2Vector
-    : public gtsam::NoiseModelFactor1<gpmp2::Pose2Vector> {
+    : public gtsam::NoiseModelFactorN<gpmp2::Pose2Vector> {
  private:
   // typedefs
   typedef JointLimitFactorPose2Vector This;
-  typedef gtsam::NoiseModelFactor1<gpmp2::Pose2Vector> Base;
+  typedef gtsam::NoiseModelFactorN<gpmp2::Pose2Vector> Base;
 
   // joint limit value
   gtsam::Vector down_limit_, up_limit_;
@@ -65,11 +65,12 @@ class JointLimitFactorPose2Vector
           "[JointLimitFactorVector] ERROR: limit vector dim does not fit.");
   }
 
-  virtual ~JointLimitFactorPose2Vector() {}
+  ~JointLimitFactorPose2Vector() {}
 
   /// error function
-  gtsam::Vector evaluateError(const gpmp2::Pose2Vector& pose,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const gpmp2::Pose2Vector& pose,
+      gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
     // get configuration
     const gtsam::Vector& conf = pose.configuration();
@@ -83,7 +84,7 @@ class JointLimitFactorPose2Vector
         double Hp;
         err(i + 3) =
             hingeLossJointLimitCost(conf(i), down_limit_(i + 3),
-                                    up_limit_(i + 3), limit_thresh_(i + 3), Hp);
+                                    up_limit_(i + 3), limit_thresh_(i + 3), &Hp);
         (*H1)(i + 3, i + 3) = Hp;
       } else {
         err(i + 3) =
@@ -95,7 +96,7 @@ class JointLimitFactorPose2Vector
   }
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/kinematics/JointLimitFactorVector.h
+++ b/gpmp2/kinematics/JointLimitFactorVector.h
@@ -97,6 +97,7 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactorN<gtsam::Vector> {
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -104,6 +105,7 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactorN<gtsam::Vector> {
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/JointLimitFactorVector.h
+++ b/gpmp2/kinematics/JointLimitFactorVector.h
@@ -34,7 +34,7 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /**
    * Constructor
@@ -61,9 +61,8 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
   virtual ~JointLimitFactorVector() {}
 
   /// error function
-  gtsam::Vector evaluateError(
-      const gtsam::Vector& conf,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Vector& conf,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
     if (H1) *H1 = Matrix::Zero(conf.size(), conf.size());
     Vector err(conf.size());
@@ -83,7 +82,7 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/JointLimitFactorVector.h
+++ b/gpmp2/kinematics/JointLimitFactorVector.h
@@ -20,11 +20,11 @@ namespace gpmp2 {
 /**
  * unary factor to apply joint limit cost to vector configuration space
  */
-class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
+class JointLimitFactorVector : public gtsam::NoiseModelFactorN<gtsam::Vector> {
  private:
   // typedefs
   typedef JointLimitFactorVector This;
-  typedef gtsam::NoiseModelFactor1<gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<gtsam::Vector> Base;
 
   // joint limit value
   gtsam::Vector down_limit_, up_limit_;
@@ -58,11 +58,12 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
           "[JointLimitFactorVector] ERROR: limit vector dim does not fit.");
   }
 
-  virtual ~JointLimitFactorVector() {}
+  ~JointLimitFactorVector() {}
 
   /// error function
-  gtsam::Vector evaluateError(const gtsam::Vector& conf,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const gtsam::Vector& conf,
+      gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
     if (H1) *H1 = Matrix::Zero(conf.size(), conf.size());
     Vector err(conf.size());
@@ -70,7 +71,7 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
       if (H1) {
         double Hp;
         err(i) = hingeLossJointLimitCost(conf(i), down_limit_(i), up_limit_(i),
-                                         limit_thresh_(i), Hp);
+                                         limit_thresh_(i), &Hp);
         (*H1)(i, i) = Hp;
       } else {
         err(i) = hingeLossJointLimitCost(conf(i), down_limit_(i), up_limit_(i),
@@ -81,7 +82,7 @@ class JointLimitFactorVector : public gtsam::NoiseModelFactor1<gtsam::Vector> {
   }
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/kinematics/PointRobot.cpp
+++ b/gpmp2/kinematics/PointRobot.cpp
@@ -14,11 +14,10 @@ namespace gpmp2 {
 /* ************************************************************************** */
 void PointRobot::forwardKinematics(
     const Vector& jp, std::optional<const Vector> jv,
-    std::vector<gtsam::Pose3>& jpx,
-    std::optional<std::vector<gtsam::Vector3>> jvx,
-    std::optional<std::vector<Matrix>> J_jpx_jp,
-    std::optional<std::vector<Matrix>> J_jvx_jp,
-    std::optional<std::vector<Matrix>> J_jvx_jv) const {
+    std::vector<gtsam::Pose3>& jpx, std::vector<gtsam::Vector3>* jvx,
+    gtsam::OptionalMatrixVecType J_jpx_jp,
+    gtsam::OptionalMatrixVecType J_jvx_jp,
+    gtsam::OptionalMatrixVecType J_jvx_jv) const {
   // space for output
   jpx.resize(nr_links());
   if (jvx) jvx->resize(nr_links());

--- a/gpmp2/kinematics/PointRobot.cpp
+++ b/gpmp2/kinematics/PointRobot.cpp
@@ -13,12 +13,12 @@ namespace gpmp2 {
 
 /* ************************************************************************** */
 void PointRobot::forwardKinematics(
-    const Vector& jp, boost::optional<const Vector&> jv,
+    const Vector& jp, std::optional<const Vector> jv,
     std::vector<gtsam::Pose3>& jpx,
-    boost::optional<std::vector<gtsam::Vector3>&> jvx,
-    boost::optional<std::vector<Matrix>&> J_jpx_jp,
-    boost::optional<std::vector<Matrix>&> J_jvx_jp,
-    boost::optional<std::vector<Matrix>&> J_jvx_jv) const {
+    std::optional<std::vector<gtsam::Vector3>> jvx,
+    std::optional<std::vector<Matrix>> J_jpx_jp,
+    std::optional<std::vector<Matrix>> J_jvx_jp,
+    std::optional<std::vector<Matrix>> J_jvx_jv) const {
   // space for output
   jpx.resize(nr_links());
   if (jvx) jvx->resize(nr_links());

--- a/gpmp2/kinematics/PointRobot.h
+++ b/gpmp2/kinematics/PointRobot.h
@@ -49,13 +49,13 @@ class GPMP2_EXPORT PointRobot
    *  @param jvx  robot velocity in work space
    *  @param J_jpx_jp et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const gtsam::Vector& jp, std::optional<const gtsam::Vector> jv,
-      std::vector<gtsam::Pose3>& jpx,
-      std::optional<std::vector<gtsam::Vector3>> jvx,
-      std::optional<std::vector<gtsam::Matrix>> J_jpx_jp = {},
-      std::optional<std::vector<gtsam::Matrix>> J_jvx_jp = {},
-      std::optional<std::vector<gtsam::Matrix>> J_jvx_jv = {}) const;
+  void forwardKinematics(const gtsam::Vector& jp,
+                         std::optional<const gtsam::Vector> jv,
+                         std::vector<gtsam::Pose3>& jpx,
+                         std::vector<gtsam::Vector3>* jvx = nullptr,
+                         gtsam::OptionalMatrixVecType J_jpx_jp = nullptr,
+                         gtsam::OptionalMatrixVecType J_jvx_jp = nullptr,
+                         gtsam::OptionalMatrixVecType J_jvx_jv = nullptr) const;
 
 };  // PointRobot
 

--- a/gpmp2/kinematics/PointRobot.h
+++ b/gpmp2/kinematics/PointRobot.h
@@ -50,13 +50,12 @@ class GPMP2_EXPORT PointRobot
    *  @param J_jpx_jp et al. optional Jacobians
    **/
   void forwardKinematics(
-      const gtsam::Vector& jp, boost::optional<const gtsam::Vector&> jv,
+      const gtsam::Vector& jp, std::optional<const gtsam::Vector> jv,
       std::vector<gtsam::Pose3>& jpx,
-      boost::optional<std::vector<gtsam::Vector3>&> jvx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jpx_jp = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jvx_jp = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_jvx_jv =
-          boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> jvx,
+      std::optional<std::vector<gtsam::Matrix>> J_jpx_jp = {},
+      std::optional<std::vector<gtsam::Matrix>> J_jvx_jp = {},
+      std::optional<std::vector<gtsam::Matrix>> J_jvx_jv = {}) const;
 
 };  // PointRobot
 

--- a/gpmp2/kinematics/Pose2Mobile2Arms.cpp
+++ b/gpmp2/kinematics/Pose2Mobile2Arms.cpp
@@ -35,12 +35,12 @@ Pose2Mobile2Arms::Pose2Mobile2Arms(const Arm& arm1, const Arm& arm2,
 
 /* ************************************************************************** */
 void Pose2Mobile2Arms::forwardKinematics(
-    const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+    const Pose2Vector& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    boost::optional<std::vector<gtsam::Vector3>&> vx,
-    boost::optional<std::vector<gtsam::Matrix>&> J_px_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_v) const {
+    std::optional<std::vector<gtsam::Vector3>> vx,
+    std::optional<std::vector<gtsam::Matrix>> J_px_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
   if (v)
     throw runtime_error("[Pose2Mobile2Arms] TODO: velocity not implemented");
 
@@ -85,12 +85,12 @@ void Pose2Mobile2Arms::forwardKinematics(
 
   arm1_.updateBasePose(arm1_base);
   arm1_.forwardKinematics(
-      p.configuration().head(arm1_.dof()), boost::none, arm1jpx, boost::none,
-      J_px_p ? boost::optional<vector<Matrix>&>(Jarm1_jpx_jp) : boost::none);
+      p.configuration().head(arm1_.dof()), {}, arm1jpx, {},
+      J_px_p ? std::optional<vector<Matrix>>(Jarm1_jpx_jp) : std::nullopt);
   arm2_.updateBasePose(arm2_base);
   arm2_.forwardKinematics(
-      p.configuration().tail(arm2_.dof()), boost::none, arm2jpx, boost::none,
-      J_px_p ? boost::optional<vector<Matrix>&>(Jarm2_jpx_jp) : boost::none);
+      p.configuration().tail(arm2_.dof()), {}, arm2jpx, {},
+      J_px_p ? std::optional<vector<Matrix>>(Jarm2_jpx_jp) : std::nullopt);
 
   for (size_t i = 0; i < arm1_.dof(); i++) {
     px[i + 1] = arm1jpx[i];

--- a/gpmp2/kinematics/Pose2Mobile2Arms.cpp
+++ b/gpmp2/kinematics/Pose2Mobile2Arms.cpp
@@ -36,11 +36,9 @@ Pose2Mobile2Arms::Pose2Mobile2Arms(const Arm& arm1, const Arm& arm2,
 /* ************************************************************************** */
 void Pose2Mobile2Arms::forwardKinematics(
     const Pose2Vector& p, std::optional<const gtsam::Vector> v,
-    std::vector<gtsam::Pose3>& px,
-    std::optional<std::vector<gtsam::Vector3>> vx,
-    std::optional<std::vector<gtsam::Matrix>> J_px_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
+    std::vector<gtsam::Pose3>& px, std::vector<gtsam::Vector3>* vx,
+    gtsam::OptionalMatrixVecType J_px_p, gtsam::OptionalMatrixVecType J_vx_p,
+    gtsam::OptionalMatrixVecType J_vx_v) const {
   if (v)
     throw runtime_error("[Pose2Mobile2Arms] TODO: velocity not implemented");
 
@@ -84,13 +82,11 @@ void Pose2Mobile2Arms::forwardKinematics(
   vector<Matrix> Jarm1_jpx_jp, Jarm2_jpx_jp;
 
   arm1_.updateBasePose(arm1_base);
-  arm1_.forwardKinematics(
-      p.configuration().head(arm1_.dof()), {}, arm1jpx, {},
-      J_px_p ? std::optional<vector<Matrix>>(Jarm1_jpx_jp) : std::nullopt);
+  arm1_.forwardKinematics(p.configuration().head(arm1_.dof()), {}, arm1jpx, {},
+                          J_px_p ? &Jarm1_jpx_jp : nullptr);
   arm2_.updateBasePose(arm2_base);
-  arm2_.forwardKinematics(
-      p.configuration().tail(arm2_.dof()), {}, arm2jpx, {},
-      J_px_p ? std::optional<vector<Matrix>>(Jarm2_jpx_jp) : std::nullopt);
+  arm2_.forwardKinematics(p.configuration().tail(arm2_.dof()), {}, arm2jpx, {},
+                          J_px_p ? &Jarm2_jpx_jp : nullptr);
 
   for (size_t i = 0; i < arm1_.dof(); i++) {
     px[i + 1] = arm1jpx[i];

--- a/gpmp2/kinematics/Pose2Mobile2Arms.h
+++ b/gpmp2/kinematics/Pose2Mobile2Arms.h
@@ -58,12 +58,12 @@ class GPMP2_EXPORT Pose2Mobile2Arms
    *  @param J_px_p et al. optional Jacobians
    **/
   void forwardKinematics(
-      const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
       std::vector<gtsam::Pose3>& px,
-      boost::optional<std::vector<gtsam::Vector3>&> vx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_px_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_v = boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> vx,
+      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
 
   /// accesses
   const Arm& arm1() const { return arm1_; }

--- a/gpmp2/kinematics/Pose2Mobile2Arms.h
+++ b/gpmp2/kinematics/Pose2Mobile2Arms.h
@@ -57,13 +57,13 @@ class GPMP2_EXPORT Pose2Mobile2Arms
    *  @param vx link velocity in work space
    *  @param J_px_p et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
-      std::vector<gtsam::Pose3>& px,
-      std::optional<std::vector<gtsam::Vector3>> vx,
-      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
+  void forwardKinematics(const Pose2Vector& p,
+                         std::optional<const gtsam::Vector> v,
+                         std::vector<gtsam::Pose3>& px,
+                         std::vector<gtsam::Vector3>* vx = nullptr,
+                         gtsam::OptionalMatrixVecType J_px_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_v = nullptr) const;
 
   /// accesses
   const Arm& arm1() const { return arm1_; }

--- a/gpmp2/kinematics/Pose2MobileArm.cpp
+++ b/gpmp2/kinematics/Pose2MobileArm.cpp
@@ -28,12 +28,12 @@ Pose2MobileArm::Pose2MobileArm(const Arm& arm, const gtsam::Pose3& base_T_arm)
 
 /* ************************************************************************** */
 void Pose2MobileArm::forwardKinematics(
-    const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+    const Pose2Vector& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    boost::optional<std::vector<gtsam::Vector3>&> vx,
-    boost::optional<std::vector<gtsam::Matrix>&> J_px_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_v) const {
+    std::optional<std::vector<gtsam::Vector3>> vx,
+    std::optional<std::vector<gtsam::Matrix>> J_px_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
   if (v) throw runtime_error("[Pose2MobileArm] TODO: velocity not implemented");
 
   if (!v && (vx || J_vx_p || J_vx_v))
@@ -83,16 +83,16 @@ void Pose2MobileArm::forwardKinematics(
   if (v) {
     const Vector varm = v->tail(arm_.dof());
     arm_.forwardKinematics(
-        p.configuration(), boost::optional<const Vector&>(varm), armjpx,
-        vx ? boost::optional<vector<Vector3>&>(armjvx) : boost::none,
-        J_px_p ? boost::optional<vector<Matrix>&>(Jarm_jpx_jp) : boost::none,
-        J_vx_p ? boost::optional<vector<Matrix>&>(Jarm_jvx_jp) : boost::none,
-        J_vx_v ? boost::optional<vector<Matrix>&>(Jarm_jvx_jv) : boost::none);
+        p.configuration(), std::optional<const Vector>(varm), armjpx,
+        vx ? std::optional<vector<Vector3>>(armjvx) : std::nullopt,
+        J_px_p ? std::optional<vector<Matrix>>(Jarm_jpx_jp) : std::nullopt,
+        J_vx_p ? std::optional<vector<Matrix>>(Jarm_jvx_jp) : std::nullopt,
+        J_vx_v ? std::optional<vector<Matrix>>(Jarm_jvx_jv) : std::nullopt);
   } else {
     arm_.forwardKinematics(
-        p.configuration(), boost::none, armjpx,
-        vx ? boost::optional<vector<Vector3>&>(armjvx) : boost::none,
-        J_px_p ? boost::optional<vector<Matrix>&>(Jarm_jpx_jp) : boost::none);
+        p.configuration(), {}, armjpx,
+        vx ? std::optional<vector<Vector3>>(armjvx) : std::nullopt,
+        J_px_p ? std::optional<vector<Matrix>>(Jarm_jpx_jp) : std::nullopt);
   }
 
   for (size_t i = 0; i < arm_.dof(); i++) {

--- a/gpmp2/kinematics/Pose2MobileArm.h
+++ b/gpmp2/kinematics/Pose2MobileArm.h
@@ -55,13 +55,13 @@ class GPMP2_EXPORT Pose2MobileArm
    *  @param vx link velocity in work space
    *  @param J_px_p et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
-      std::vector<gtsam::Pose3>& px,
-      std::optional<std::vector<gtsam::Vector3>> vx,
-      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
+  void forwardKinematics(const Pose2Vector& p,
+                         std::optional<const gtsam::Vector> v,
+                         std::vector<gtsam::Pose3>& px,
+                         std::vector<gtsam::Vector3>* vx = nullptr,
+                         gtsam::OptionalMatrixVecType J_px_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_v = nullptr) const;
 
   /// accesses
   const gtsam::Pose3& base_T_arm() const { return base_T_arm_; }

--- a/gpmp2/kinematics/Pose2MobileArm.h
+++ b/gpmp2/kinematics/Pose2MobileArm.h
@@ -56,12 +56,12 @@ class GPMP2_EXPORT Pose2MobileArm
    *  @param J_px_p et al. optional Jacobians
    **/
   void forwardKinematics(
-      const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
       std::vector<gtsam::Pose3>& px,
-      boost::optional<std::vector<gtsam::Vector3>&> vx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_px_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_v = boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> vx,
+      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
 
   /// accesses
   const gtsam::Pose3& base_T_arm() const { return base_T_arm_; }

--- a/gpmp2/kinematics/Pose2MobileBase.cpp
+++ b/gpmp2/kinematics/Pose2MobileBase.cpp
@@ -17,12 +17,12 @@ namespace gpmp2 {
 
 /* ************************************************************************** */
 void Pose2MobileBase::forwardKinematics(
-    const gtsam::Pose2& p, boost::optional<const gtsam::Vector&> v,
+    const gtsam::Pose2& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    boost::optional<std::vector<gtsam::Vector3>&> vx,
-    boost::optional<std::vector<gtsam::Matrix>&> J_px_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_v) const {
+    std::optional<std::vector<gtsam::Vector3>> vx,
+    std::optional<std::vector<gtsam::Matrix>> J_px_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
   if (v)
     throw runtime_error("[Pose2MobileBase] TODO: velocity not implemented");
 

--- a/gpmp2/kinematics/Pose2MobileBase.cpp
+++ b/gpmp2/kinematics/Pose2MobileBase.cpp
@@ -19,10 +19,10 @@ namespace gpmp2 {
 void Pose2MobileBase::forwardKinematics(
     const gtsam::Pose2& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    std::optional<std::vector<gtsam::Vector3>> vx,
-    std::optional<std::vector<gtsam::Matrix>> J_px_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
+    std::vector<gtsam::Vector3>* vx,
+    gtsam::OptionalMatrixVecType J_px_p,
+    gtsam::OptionalMatrixVecType J_vx_p,
+    gtsam::OptionalMatrixVecType J_vx_v) const {
   if (v)
     throw runtime_error("[Pose2MobileBase] TODO: velocity not implemented");
 

--- a/gpmp2/kinematics/Pose2MobileBase.h
+++ b/gpmp2/kinematics/Pose2MobileBase.h
@@ -45,12 +45,12 @@ class GPMP2_EXPORT Pose2MobileBase
    *  @param J_px_p et al. optional Jacobians
    **/
   void forwardKinematics(
-      const gtsam::Pose2& p, boost::optional<const gtsam::Vector&> v,
+      const gtsam::Pose2& p, std::optional<const gtsam::Vector> v,
       std::vector<gtsam::Pose3>& px,
-      boost::optional<std::vector<gtsam::Vector3>&> vx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_px_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_v = boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> vx,
+      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/Pose2MobileBase.h
+++ b/gpmp2/kinematics/Pose2MobileBase.h
@@ -44,13 +44,13 @@ class GPMP2_EXPORT Pose2MobileBase
    *  @param vx link velocity in work space
    *  @param J_px_p et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const gtsam::Pose2& p, std::optional<const gtsam::Vector> v,
-      std::vector<gtsam::Pose3>& px,
-      std::optional<std::vector<gtsam::Vector3>> vx,
-      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
+  void forwardKinematics(const gtsam::Pose2& p,
+                         std::optional<const gtsam::Vector> v,
+                         std::vector<gtsam::Pose3>& px,
+                         std::vector<gtsam::Vector3>* vx = nullptr,
+                         gtsam::OptionalMatrixVecType J_px_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_v = nullptr) const;
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/Pose2MobileVetLin2Arms.cpp
+++ b/gpmp2/kinematics/Pose2MobileVetLin2Arms.cpp
@@ -40,12 +40,12 @@ Pose2MobileVetLin2Arms::Pose2MobileVetLin2Arms(const Arm& arm1, const Arm& arm2,
 
 /* ************************************************************************** */
 void Pose2MobileVetLin2Arms::forwardKinematics(
-    const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+    const Pose2Vector& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    boost::optional<std::vector<gtsam::Vector3>&> vx,
-    boost::optional<std::vector<gtsam::Matrix>&> J_px_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_v) const {
+    std::optional<std::vector<gtsam::Vector3>> vx,
+    std::optional<std::vector<gtsam::Matrix>> J_px_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
   if (v)
     throw runtime_error(
         "[Pose2MobileVetLin2Arms] TODO: velocity not implemented");
@@ -101,14 +101,12 @@ void Pose2MobileVetLin2Arms::forwardKinematics(
   // arm2.dof
   arm1_.updateBasePose(arm1_base);
   arm1_.forwardKinematics(
-      p.configuration().segment(1, arm1_.dof()), boost::none, arm1jpx,
-      boost::none,
-      J_px_p ? boost::optional<vector<Matrix>&>(Jarm1_jpx_jp) : boost::none);
+      p.configuration().segment(1, arm1_.dof()), {}, arm1jpx, {},
+      J_px_p ? std::optional<vector<Matrix>>(Jarm1_jpx_jp) : std::nullopt);
   arm2_.updateBasePose(arm2_base);
   arm2_.forwardKinematics(
-      p.configuration().segment(1 + arm1_.dof(), arm2_.dof()), boost::none,
-      arm2jpx, boost::none,
-      J_px_p ? boost::optional<vector<Matrix>&>(Jarm2_jpx_jp) : boost::none);
+      p.configuration().segment(1 + arm1_.dof(), arm2_.dof()), {}, arm2jpx, {},
+      J_px_p ? std::optional<vector<Matrix>>(Jarm2_jpx_jp) : std::nullopt);
 
   for (size_t i = 0; i < arm1_.dof(); i++) {
     px[i + 2] = arm1jpx[i];

--- a/gpmp2/kinematics/Pose2MobileVetLin2Arms.cpp
+++ b/gpmp2/kinematics/Pose2MobileVetLin2Arms.cpp
@@ -42,10 +42,9 @@ Pose2MobileVetLin2Arms::Pose2MobileVetLin2Arms(const Arm& arm1, const Arm& arm2,
 void Pose2MobileVetLin2Arms::forwardKinematics(
     const Pose2Vector& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    std::optional<std::vector<gtsam::Vector3>> vx,
-    std::optional<std::vector<gtsam::Matrix>> J_px_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
+    std::vector<gtsam::Vector3>* vx,
+    gtsam::OptionalMatrixVecType J_px_p, gtsam::OptionalMatrixVecType J_vx_p,
+    gtsam::OptionalMatrixVecType J_vx_v) const {
   if (v)
     throw runtime_error(
         "[Pose2MobileVetLin2Arms] TODO: velocity not implemented");
@@ -100,13 +99,12 @@ void Pose2MobileVetLin2Arms::forwardKinematics(
   // linear actuator use first, arm1 uses next arm1.dof, then arm2 uses last
   // arm2.dof
   arm1_.updateBasePose(arm1_base);
-  arm1_.forwardKinematics(
-      p.configuration().segment(1, arm1_.dof()), {}, arm1jpx, {},
-      J_px_p ? std::optional<vector<Matrix>>(Jarm1_jpx_jp) : std::nullopt);
+  arm1_.forwardKinematics(p.configuration().segment(1, arm1_.dof()), {},
+                          arm1jpx, {}, J_px_p ? &Jarm1_jpx_jp : nullptr);
   arm2_.updateBasePose(arm2_base);
   arm2_.forwardKinematics(
       p.configuration().segment(1 + arm1_.dof(), arm2_.dof()), {}, arm2jpx, {},
-      J_px_p ? std::optional<vector<Matrix>>(Jarm2_jpx_jp) : std::nullopt);
+      J_px_p ? &Jarm2_jpx_jp : nullptr);
 
   for (size_t i = 0; i < arm1_.dof(); i++) {
     px[i + 2] = arm1jpx[i];

--- a/gpmp2/kinematics/Pose2MobileVetLin2Arms.h
+++ b/gpmp2/kinematics/Pose2MobileVetLin2Arms.h
@@ -64,12 +64,12 @@ class GPMP2_EXPORT Pose2MobileVetLin2Arms
    *  @param J_px_p et al. optional Jacobians
    **/
   void forwardKinematics(
-      const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
       std::vector<gtsam::Pose3>& px,
-      boost::optional<std::vector<gtsam::Vector3>&> vx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_px_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_v = boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> vx,
+      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
 
   /// accesses
   const Arm& arm1() const { return arm1_; }

--- a/gpmp2/kinematics/Pose2MobileVetLin2Arms.h
+++ b/gpmp2/kinematics/Pose2MobileVetLin2Arms.h
@@ -63,13 +63,13 @@ class GPMP2_EXPORT Pose2MobileVetLin2Arms
    *  @param vx link velocity in work space
    *  @param J_px_p et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
-      std::vector<gtsam::Pose3>& px,
-      std::optional<std::vector<gtsam::Vector3>> vx,
-      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
+  void forwardKinematics(const Pose2Vector& p,
+                         std::optional<const gtsam::Vector> v,
+                         std::vector<gtsam::Pose3>& px,
+                         std::vector<gtsam::Vector3>* vx = nullptr,
+                         gtsam::OptionalMatrixVecType J_px_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_v = nullptr) const;
 
   /// accesses
   const Arm& arm1() const { return arm1_; }

--- a/gpmp2/kinematics/Pose2MobileVetLinArm.cpp
+++ b/gpmp2/kinematics/Pose2MobileVetLinArm.cpp
@@ -35,12 +35,12 @@ Pose2MobileVetLinArm::Pose2MobileVetLinArm(const Arm& arm,
 
 /* ************************************************************************** */
 void Pose2MobileVetLinArm::forwardKinematics(
-    const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+    const Pose2Vector& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    boost::optional<std::vector<gtsam::Vector3>&> vx,
-    boost::optional<std::vector<gtsam::Matrix>&> J_px_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_p,
-    boost::optional<std::vector<gtsam::Matrix>&> J_vx_v) const {
+    std::optional<std::vector<gtsam::Vector3>> vx,
+    std::optional<std::vector<gtsam::Matrix>> J_px_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
+    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
   if (v) throw runtime_error("[Pose2MobileArm] TODO: velocity not implemented");
 
   if (!v && (vx || J_vx_p || J_vx_v))
@@ -89,8 +89,8 @@ void Pose2MobileVetLinArm::forwardKinematics(
 
   arm_.updateBasePose(arm_base);
   arm_.forwardKinematics(
-      p.configuration().tail(arm_.dof()), boost::none, armjpx, boost::none,
-      J_px_p ? boost::optional<vector<Matrix>&>(Jarm_jpx_jp) : boost::none);
+      p.configuration().tail(arm_.dof()), {}, armjpx, {},
+      J_px_p ? std::optional<vector<Matrix>>(Jarm_jpx_jp) : std::nullopt);
 
   for (size_t i = 0; i < arm_.dof(); i++) {
     px[i + 2] = armjpx[i];

--- a/gpmp2/kinematics/Pose2MobileVetLinArm.cpp
+++ b/gpmp2/kinematics/Pose2MobileVetLinArm.cpp
@@ -37,10 +37,9 @@ Pose2MobileVetLinArm::Pose2MobileVetLinArm(const Arm& arm,
 void Pose2MobileVetLinArm::forwardKinematics(
     const Pose2Vector& p, std::optional<const gtsam::Vector> v,
     std::vector<gtsam::Pose3>& px,
-    std::optional<std::vector<gtsam::Vector3>> vx,
-    std::optional<std::vector<gtsam::Matrix>> J_px_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_p,
-    std::optional<std::vector<gtsam::Matrix>> J_vx_v) const {
+    std::vector<gtsam::Vector3>* vx,
+    gtsam::OptionalMatrixVecType J_px_p, gtsam::OptionalMatrixVecType J_vx_p,
+    gtsam::OptionalMatrixVecType J_vx_v) const {
   if (v) throw runtime_error("[Pose2MobileArm] TODO: velocity not implemented");
 
   if (!v && (vx || J_vx_p || J_vx_v))
@@ -88,9 +87,8 @@ void Pose2MobileVetLinArm::forwardKinematics(
   vector<Matrix> Jarm_jpx_jp;
 
   arm_.updateBasePose(arm_base);
-  arm_.forwardKinematics(
-      p.configuration().tail(arm_.dof()), {}, armjpx, {},
-      J_px_p ? std::optional<vector<Matrix>>(Jarm_jpx_jp) : std::nullopt);
+  arm_.forwardKinematics(p.configuration().tail(arm_.dof()), {}, armjpx, {},
+                         J_px_p ? &Jarm_jpx_jp : nullptr);
 
   for (size_t i = 0; i < arm_.dof(); i++) {
     px[i + 2] = armjpx[i];

--- a/gpmp2/kinematics/Pose2MobileVetLinArm.h
+++ b/gpmp2/kinematics/Pose2MobileVetLinArm.h
@@ -62,12 +62,12 @@ class GPMP2_EXPORT Pose2MobileVetLinArm
    *  @param J_px_p et al. optional Jacobians
    **/
   void forwardKinematics(
-      const Pose2Vector& p, boost::optional<const gtsam::Vector&> v,
+      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
       std::vector<gtsam::Pose3>& px,
-      boost::optional<std::vector<gtsam::Vector3>&> vx,
-      boost::optional<std::vector<gtsam::Matrix>&> J_px_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_p = boost::none,
-      boost::optional<std::vector<gtsam::Matrix>&> J_vx_v = boost::none) const;
+      std::optional<std::vector<gtsam::Vector3>> vx,
+      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
+      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
 
   /// accesses
   const gtsam::Pose3& base_T_torso() const { return base_T_torso_; }

--- a/gpmp2/kinematics/Pose2MobileVetLinArm.h
+++ b/gpmp2/kinematics/Pose2MobileVetLinArm.h
@@ -61,13 +61,13 @@ class GPMP2_EXPORT Pose2MobileVetLinArm
    *  @param vx link velocity in work space
    *  @param J_px_p et al. optional Jacobians
    **/
-  void forwardKinematics(
-      const Pose2Vector& p, std::optional<const gtsam::Vector> v,
-      std::vector<gtsam::Pose3>& px,
-      std::optional<std::vector<gtsam::Vector3>> vx,
-      std::optional<std::vector<gtsam::Matrix>> J_px_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_p = {},
-      std::optional<std::vector<gtsam::Matrix>> J_vx_v = {}) const;
+  void forwardKinematics(const Pose2Vector& p,
+                         std::optional<const gtsam::Vector> v,
+                         std::vector<gtsam::Pose3>& px,
+                         std::vector<gtsam::Vector3>* vx = nullptr,
+                         gtsam::OptionalMatrixVecType J_px_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_p = nullptr,
+                         gtsam::OptionalMatrixVecType J_vx_v = nullptr) const;
 
   /// accesses
   const gtsam::Pose3& base_T_torso() const { return base_T_torso_; }

--- a/gpmp2/kinematics/RobotModel-inl.h
+++ b/gpmp2/kinematics/RobotModel-inl.h
@@ -12,15 +12,14 @@ namespace gpmp2 {
 template <class FK>
 void RobotModel<FK>::sphereCenters(
     const Pose& jp, std::vector<gtsam::Point3>& sph_centers,
-    boost::optional<std::vector<gtsam::Matrix>&> J_point_conf) const {
+    std::optional<std::vector<gtsam::Matrix>> J_point_conf) const {
   // apply fk
   std::vector<gtsam::Pose3> link_poses;
   std::vector<gtsam::Matrix> J_pose_jp;
   if (J_point_conf)
-    fk_model_.forwardKinematics(jp, boost::none, link_poses, boost::none,
-                                J_pose_jp);
+    fk_model_.forwardKinematics(jp, {}, link_poses, {}, J_pose_jp);
   else
-    fk_model_.forwardKinematics(jp, boost::none, link_poses, boost::none);
+    fk_model_.forwardKinematics(jp, {}, link_poses, {});
 
   // convert to sphere centers
   sph_centers.resize(nr_body_spheres());
@@ -47,15 +46,14 @@ void RobotModel<FK>::sphereCenters(
 template <class FK>
 gtsam::Point3 RobotModel<FK>::sphereCenter(
     size_t sph_idx, const Pose& jp,
-    boost::optional<gtsam::Matrix&> J_point_conf) const {
+    std::optional<gtsam::Matrix> J_point_conf) const {
   // apply fk
   std::vector<gtsam::Pose3> link_poses;
   std::vector<gtsam::Matrix> J_pose_jp;
   if (J_point_conf)
-    fk_model_.forwardKinematics(jp, boost::none, link_poses, boost::none,
-                                J_pose_jp);
+    fk_model_.forwardKinematics(jp, {}, link_poses, {}, J_pose_jp);
   else
-    fk_model_.forwardKinematics(jp, boost::none, link_poses, boost::none);
+    fk_model_.forwardKinematics(jp, {}, link_poses, {});
 
   gtsam::Point3 sph_center;
   if (J_point_conf) {

--- a/gpmp2/kinematics/RobotModel-inl.h
+++ b/gpmp2/kinematics/RobotModel-inl.h
@@ -12,14 +12,14 @@ namespace gpmp2 {
 template <class FK>
 void RobotModel<FK>::sphereCenters(
     const Pose& jp, std::vector<gtsam::Point3>& sph_centers,
-    std::optional<std::vector<gtsam::Matrix>> J_point_conf) const {
+    gtsam::OptionalMatrixVecType J_point_conf) const {
   // apply fk
   std::vector<gtsam::Pose3> link_poses;
   std::vector<gtsam::Matrix> J_pose_jp;
   if (J_point_conf)
-    fk_model_.forwardKinematics(jp, {}, link_poses, {}, J_pose_jp);
+    fk_model_.forwardKinematics(jp, {}, link_poses, nullptr, &J_pose_jp);
   else
-    fk_model_.forwardKinematics(jp, {}, link_poses, {});
+    fk_model_.forwardKinematics(jp, {}, link_poses, nullptr);
 
   // convert to sphere centers
   sph_centers.resize(nr_body_spheres());
@@ -46,14 +46,14 @@ void RobotModel<FK>::sphereCenters(
 template <class FK>
 gtsam::Point3 RobotModel<FK>::sphereCenter(
     size_t sph_idx, const Pose& jp,
-    std::optional<gtsam::Matrix> J_point_conf) const {
+    gtsam::OptionalMatrixType J_point_conf) const {
   // apply fk
   std::vector<gtsam::Pose3> link_poses;
   std::vector<gtsam::Matrix> J_pose_jp;
   if (J_point_conf)
-    fk_model_.forwardKinematics(jp, {}, link_poses, {}, J_pose_jp);
+    fk_model_.forwardKinematics(jp, {}, link_poses, nullptr, &J_pose_jp);
   else
-    fk_model_.forwardKinematics(jp, {}, link_poses, {});
+    fk_model_.forwardKinematics(jp, {}, link_poses, nullptr);
 
   gtsam::Point3 sph_center;
   if (J_point_conf) {

--- a/gpmp2/kinematics/RobotModel.h
+++ b/gpmp2/kinematics/RobotModel.h
@@ -59,16 +59,15 @@ class RobotModel {
 
   /// given pose in configuration space, solve sphere center vector in work
   /// space with optional associated jacobian of pose
-  void sphereCenters(
-      const Pose& jp, std::vector<gtsam::Point3>& sph_centers,
-      std::optional<std::vector<gtsam::Matrix>> J_point_conf = {}) const;
+  void sphereCenters(const Pose& jp, std::vector<gtsam::Point3>& sph_centers,
+                     gtsam::OptionalMatrixVecType J_point_conf = nullptr) const;
 
   /// given pose in configuration space, solve a single sphere center in work
   /// space for fast call of a single sphere with optional associated jacobian
   /// of pose
   gtsam::Point3 sphereCenter(
       size_t sph_idx, const Pose& jp,
-      std::optional<gtsam::Matrix> J_point_conf = {}) const;
+      gtsam::OptionalMatrixType J_point_conf = nullptr) const;
 
   /// given pose in configuration space, solve sphere center vector in work
   /// space matlab version, no jacobians output matrix 3 * nr_sphere

--- a/gpmp2/kinematics/RobotModel.h
+++ b/gpmp2/kinematics/RobotModel.h
@@ -59,16 +59,16 @@ class RobotModel {
 
   /// given pose in configuration space, solve sphere center vector in work
   /// space with optional associated jacobian of pose
-  void sphereCenters(const Pose& jp, std::vector<gtsam::Point3>& sph_centers,
-                     boost::optional<std::vector<gtsam::Matrix>&> J_point_conf =
-                         boost::none) const;
+  void sphereCenters(
+      const Pose& jp, std::vector<gtsam::Point3>& sph_centers,
+      std::optional<std::vector<gtsam::Matrix>> J_point_conf = {}) const;
 
   /// given pose in configuration space, solve a single sphere center in work
   /// space for fast call of a single sphere with optional associated jacobian
   /// of pose
   gtsam::Point3 sphereCenter(
       size_t sph_idx, const Pose& jp,
-      boost::optional<gtsam::Matrix&> J_point_conf = boost::none) const;
+      std::optional<gtsam::Matrix> J_point_conf = {}) const;
 
   /// given pose in configuration space, solve sphere center vector in work
   /// space matlab version, no jacobians output matrix 3 * nr_sphere

--- a/gpmp2/kinematics/VelocityLimitFactorVector.h
+++ b/gpmp2/kinematics/VelocityLimitFactorVector.h
@@ -21,11 +21,11 @@ namespace gpmp2 {
  * unary factor to apply joint limit cost to vector configuration space
  */
 class VelocityLimitFactorVector
-    : public gtsam::NoiseModelFactor1<gtsam::Vector> {
+    : public gtsam::NoiseModelFactorN<gtsam::Vector> {
  private:
   // typedefs
   typedef VelocityLimitFactorVector This;
-  typedef gtsam::NoiseModelFactor1<gtsam::Vector> Base;
+  typedef gtsam::NoiseModelFactorN<gtsam::Vector> Base;
 
   // joint velocity limit value for each joint
   gtsam::Vector vel_limit_;
@@ -63,8 +63,9 @@ class VelocityLimitFactorVector
   virtual ~VelocityLimitFactorVector() {}
 
   /// error function
-  gtsam::Vector evaluateError(const gtsam::Vector& conf,
-                              std::optional<gtsam::Matrix> H1 = {}) const {
+  gtsam::Vector evaluateError(
+      const gtsam::Vector& conf,
+      gtsam::OptionalMatrixType H1 = nullptr) const override {
     using namespace gtsam;
     if (H1) *H1 = Matrix::Zero(conf.size(), conf.size());
     Vector err(conf.size());
@@ -72,7 +73,7 @@ class VelocityLimitFactorVector
       if (H1) {
         double Hp;
         err(i) = hingeLossJointLimitCost(conf(i), -vel_limit_(i), vel_limit_(i),
-                                         limit_thresh_(i), Hp);
+                                         limit_thresh_(i), &Hp);
         (*H1)(i, i) = Hp;
       } else {
         err(i) = hingeLossJointLimitCost(conf(i), -vel_limit_(i), vel_limit_(i),

--- a/gpmp2/kinematics/VelocityLimitFactorVector.h
+++ b/gpmp2/kinematics/VelocityLimitFactorVector.h
@@ -99,6 +99,7 @@ class VelocityLimitFactorVector
   }
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -106,6 +107,7 @@ class VelocityLimitFactorVector
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/VelocityLimitFactorVector.h
+++ b/gpmp2/kinematics/VelocityLimitFactorVector.h
@@ -35,7 +35,7 @@ class VelocityLimitFactorVector
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /**
    * Constructor
@@ -63,9 +63,8 @@ class VelocityLimitFactorVector
   virtual ~VelocityLimitFactorVector() {}
 
   /// error function
-  gtsam::Vector evaluateError(
-      const gtsam::Vector& conf,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const {
+  gtsam::Vector evaluateError(const gtsam::Vector& conf,
+                              std::optional<gtsam::Matrix> H1 = {}) const {
     using namespace gtsam;
     if (H1) *H1 = Matrix::Zero(conf.size(), conf.size());
     Vector err(conf.size());
@@ -85,7 +84,7 @@ class VelocityLimitFactorVector
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/kinematics/mobileBaseUtils.cpp
+++ b/gpmp2/kinematics/mobileBaseUtils.cpp
@@ -15,7 +15,7 @@ namespace gpmp2 {
 
 /* ************************************************************************** */
 gtsam::Pose3 computeBasePose3(const gtsam::Pose2& base_pose2,
-                              gtsam::OptionalJacobian<6, 3> J = boost::none) {
+                              gtsam::OptionalJacobian<6, 3> J = {}) {
   if (J) {
     J->setZero();
     const gtsam::Matrix3 Hzrot3 =
@@ -29,9 +29,9 @@ gtsam::Pose3 computeBasePose3(const gtsam::Pose2& base_pose2,
 }
 
 /* ************************************************************************** */
-gtsam::Pose3 computeBaseTransPose3(
-    const gtsam::Pose2& base_pose2, const gtsam::Pose3& base_T_trans,
-    gtsam::OptionalJacobian<6, 3> J = boost::none) {
+gtsam::Pose3 computeBaseTransPose3(const gtsam::Pose2& base_pose2,
+                                   const gtsam::Pose3& base_T_trans,
+                                   gtsam::OptionalJacobian<6, 3> J = {}) {
   if (J) {
     gtsam::Matrix63 Hbasep3;
     const gtsam::Pose3 base_pose3 = computeBasePose3(base_pose2, Hbasep3);
@@ -48,7 +48,7 @@ gtsam::Pose3 computeBaseTransPose3(
 gtsam::Pose3 liftBasePose3(const gtsam::Pose2& base_pose2, double lift,
                            const gtsam::Pose3& base_T_trans,
                            bool reverse_linact,
-                           gtsam::OptionalJacobian<6, 4> J = boost::none) {
+                           gtsam::OptionalJacobian<6, 4> J = {}) {
   // a const pose to lift base
   Pose3 lift_base_pose;
   // Matrix63 Jliftbase_z;

--- a/gpmp2/kinematics/mobileBaseUtils.h
+++ b/gpmp2/kinematics/mobileBaseUtils.h
@@ -12,17 +12,17 @@ namespace gpmp2 {
 
 /// convert 2D pose to 3D pose on x-y plane, with jacobian
 gtsam::Pose3 computeBasePose3(const gtsam::Pose2& base_pose2,
-                              gtsam::OptionalJacobian<6, 3> J = boost::none);
+                              gtsam::OptionalJacobian<6, 3> J = {});
 
 /// compute a pose3 given vehicle base pose2 and transform, with jacobian
-gtsam::Pose3 computeBaseTransPose3(
-    const gtsam::Pose2& base_pose2, const gtsam::Pose3& base_T_trans,
-    gtsam::OptionalJacobian<6, 3> J = boost::none);
+gtsam::Pose3 computeBaseTransPose3(const gtsam::Pose2& base_pose2,
+                                   const gtsam::Pose3& base_T_trans,
+                                   gtsam::OptionalJacobian<6, 3> J = {});
 
 /// lift arm base in z direction, with jacobian
 gtsam::Pose3 liftBasePose3(const gtsam::Pose2& base_pose2, double lift,
                            const gtsam::Pose3& base_T_trans,
                            bool reverse_linact,
-                           gtsam::OptionalJacobian<6, 4> J = boost::none);
+                           gtsam::OptionalJacobian<6, 4> J = {});
 
 }  // namespace gpmp2

--- a/gpmp2/kinematics/tests/testArm.cpp
+++ b/gpmp2/kinematics/tests/testArm.cpp
@@ -484,7 +484,7 @@ TEST(Arm, WAMexample) {
   arm.forwardKinematics(q, qdymc, pvec_act1, vvec_act, pJp_act1, vJp_act,
                         vJv_act);
   // fk no velocity
-  arm.forwardKinematics(q, boost::none, pvec_act2, boost::none, pJp_act2);
+  arm.forwardKinematics(q, {}, pvec_act2, {}, pJp_act2);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act1[0].translation(), 1e-3));
   EXPECT(assert_equal(pvec_exp[1], pvec_act1[1].translation(), 1e-3));

--- a/gpmp2/kinematics/tests/testArm.cpp
+++ b/gpmp2/kinematics/tests/testArm.cpp
@@ -19,16 +19,16 @@ using namespace gpmp2;
 Pose3 fkpose(const Arm& arm, const Vector& jp, const Vector& jv, size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  arm.forwardKinematics(jp, jv, pos, vel);
-  return pos[i];
+  arm.forwardKinematics(jp, jv, pos, &vel);
+  return pos.at(i);
 }
 
 Vector3 fkvelocity(const Arm& arm, const Vector& jp, const Vector& jv,
                    size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  arm.forwardKinematics(jp, jv, pos, vel);
-  return vel[i];
+  arm.forwardKinematics(jp, jv, pos, &vel);
+  return vel.at(i);
 }
 
 /* ************************************************************************** */
@@ -85,8 +85,8 @@ TEST(Arm, 2linkPlanarExamples) {
           std::bind(&fkvelocity, arm, q, std::placeholders::_1, size_t(1))),
       qdot, 1e-6));
 
-  arm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-                        vJv_act);
+  arm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+                        &vJv_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
@@ -139,8 +139,8 @@ TEST(Arm, 2linkPlanarExamples) {
           std::bind(&fkvelocity, arm, q, std::placeholders::_1, size_t(1))),
       qdot, 1e-6));
 
-  arm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-                        vJv_act);
+  arm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+                        &vJv_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
@@ -193,8 +193,8 @@ TEST(Arm, 2linkPlanarExamples) {
           std::bind(&fkvelocity, arm, q, std::placeholders::_1, size_t(1))),
       qdot, 1e-6));
 
-  arm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-                        vJv_act);
+  arm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+                        &vJv_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
@@ -248,8 +248,8 @@ TEST(Arm, 2linkPlanarExamples) {
           std::bind(&fkvelocity, arm, q, std::placeholders::_1, size_t(1))),
       qdot, 1e-6));
 
-  arm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-                        vJv_act);
+  arm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+                        &vJv_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
@@ -331,8 +331,8 @@ TEST(Arm, 3link3Dexample) {
           std::bind(&fkvelocity, arm, q, std::placeholders::_1, size_t(2))),
       qdot, 1e-6));
 
-  arm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-                        vJv_act);
+  arm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+                        &vJv_act);
   EXPECT(assert_equal(pointvec_exp[0], pvec_act[0].translation(), 1e-3));
   EXPECT(assert_equal(pointvec_exp[1], pvec_act[1].translation(), 1e-3));
   EXPECT(assert_equal(pointvec_exp[2], pvec_act[2].translation(), 1e-3));
@@ -481,10 +481,10 @@ TEST(Arm, WAMexample) {
       qdot, 1e-6));
 
   // full fk with velocity
-  arm.forwardKinematics(q, qdymc, pvec_act1, vvec_act, pJp_act1, vJp_act,
-                        vJv_act);
+  arm.forwardKinematics(q, qdymc, pvec_act1, &vvec_act, &pJp_act1, &vJp_act,
+                        &vJv_act);
   // fk no velocity
-  arm.forwardKinematics(q, {}, pvec_act2, {}, pJp_act2);
+  arm.forwardKinematics(q, {}, pvec_act2, nullptr, &pJp_act2);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act1[0].translation(), 1e-3));
   EXPECT(assert_equal(pvec_exp[1], pvec_act1[1].translation(), 1e-3));

--- a/gpmp2/kinematics/tests/testArmModel.cpp
+++ b/gpmp2/kinematics/tests/testArmModel.cpp
@@ -58,7 +58,7 @@ TEST(ArmModel, 2linkPlanarExamples) {
   sph_centers_exp.push_back(Point3(3.5, 1, -1));
   sph_centers_exp.push_back(Point3(4, 1, -1));
 
-  arm.sphereCenters(q, sph_centers_act, J_center_q_act);
+  arm.sphereCenters(q, sph_centers_act, &J_center_q_act);
 
   for (size_t i = 0; i < nr_sph; i++) {
     EXPECT(assert_equal(sph_centers_exp[i], sph_centers_act[i]));
@@ -67,7 +67,7 @@ TEST(ArmModel, 2linkPlanarExamples) {
             std::bind(&sph_pos_wrapper_batch, arm, std::placeholders::_1, i)),
         q, 1e-6);
     EXPECT(assert_equal(Jcq_exp, J_center_q_act[i], 1e-9));
-    EXPECT(assert_equal(sph_centers_exp[i], arm.sphereCenter(i, q, Jcq_act)));
+    EXPECT(assert_equal(sph_centers_exp[i], arm.sphereCenter(i, q, &Jcq_act)));
     Jcq_exp = numericalDerivative11(
         std::function<Point3(const Vector2&)>(
             std::bind(&sph_pos_wrapper_single, arm, std::placeholders::_1, i)),
@@ -84,7 +84,7 @@ TEST(ArmModel, 2linkPlanarExamples) {
   sph_centers_exp.push_back(Point3(2.707106781186548, 2.207106781186548, -1));
   sph_centers_exp.push_back(Point3(2.707106781186548, 2.707106781186548, -1));
 
-  arm.sphereCenters(q, sph_centers_act, J_center_q_act);
+  arm.sphereCenters(q, sph_centers_act, &J_center_q_act);
 
   for (size_t i = 0; i < nr_sph; i++) {
     EXPECT(assert_equal(sph_centers_exp[i], sph_centers_act[i]));
@@ -93,7 +93,7 @@ TEST(ArmModel, 2linkPlanarExamples) {
             std::bind(&sph_pos_wrapper_batch, arm, std::placeholders::_1, i)),
         q, 1e-6);
     EXPECT(assert_equal(Jcq_exp, J_center_q_act[i], 1e-9));
-    EXPECT(assert_equal(sph_centers_exp[i], arm.sphereCenter(i, q, Jcq_act)));
+    EXPECT(assert_equal(sph_centers_exp[i], arm.sphereCenter(i, q, &Jcq_act)));
     Jcq_exp = numericalDerivative11(
         std::function<Point3(const Vector2&)>(
             std::bind(&sph_pos_wrapper_single, arm, std::placeholders::_1, i)),

--- a/gpmp2/kinematics/tests/testGaussianPriorWorkspaceOrientation.cpp
+++ b/gpmp2/kinematics/tests/testGaussianPriorWorkspaceOrientation.cpp
@@ -39,7 +39,7 @@ TEST(GaussianPriorWorkspaceOrientationArm, error) {
   H_exp = numericalDerivative11(
       std::function<Vector3(const Vector2&)>(
           std::bind(&GaussianPriorWorkspaceOrientationArm::evaluateError,
-                    factor, std::placeholders::_1, boost::none)),
+                    factor, std::placeholders::_1, {})),
       q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testGaussianPriorWorkspaceOrientation.cpp
+++ b/gpmp2/kinematics/tests/testGaussianPriorWorkspaceOrientation.cpp
@@ -34,12 +34,12 @@ TEST(GaussianPriorWorkspaceOrientationArm, error) {
   q = Vector2(M_PI / 4.0, -M_PI / 2);
   des = Rot3(Rot3::RzRyRx(0, 0, -M_PI / 2));
   GaussianPriorWorkspaceOrientationArm factor(0, arm, 1, des, cost_model);
-  actual = factor.evaluateError(q, H_act);
+  actual = factor.evaluateError(q, &H_act);
   expect = Vector3(-0.613943126, 1.48218982, 0.613943126);
   H_exp = numericalDerivative11(
       std::function<Vector3(const Vector2&)>(
           std::bind(&GaussianPriorWorkspaceOrientationArm::evaluateError,
-                    factor, std::placeholders::_1, {})),
+                    factor, std::placeholders::_1, nullptr)),
       q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testGaussianPriorWorkspacePose.cpp
+++ b/gpmp2/kinematics/tests/testGaussianPriorWorkspacePose.cpp
@@ -34,14 +34,14 @@ TEST(GaussianPriorWorkspacePoseArm, error) {
   q = Vector2(M_PI / 4.0, -M_PI / 2);
   des = Pose3();
   GaussianPriorWorkspacePoseArm factor(0, arm, 1, des, cost_model);
-  actual = factor.evaluateError(q, H_act);
+  actual = factor.evaluateError(q, &H_act);
   expect = (Vector(6) << 0.613943126, 1.48218982, -0.613943126, 1.1609828,
             0.706727485, -0.547039678)
                .finished();
   H_exp =
       numericalDerivative11(std::function<Vector(const Vector2&)>(std::bind(
                                 &GaussianPriorWorkspacePoseArm::evaluateError,
-                                factor, std::placeholders::_1, {})),
+                                factor, std::placeholders::_1, nullptr)),
                             q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testGaussianPriorWorkspacePose.cpp
+++ b/gpmp2/kinematics/tests/testGaussianPriorWorkspacePose.cpp
@@ -41,7 +41,7 @@ TEST(GaussianPriorWorkspacePoseArm, error) {
   H_exp =
       numericalDerivative11(std::function<Vector(const Vector2&)>(std::bind(
                                 &GaussianPriorWorkspacePoseArm::evaluateError,
-                                factor, std::placeholders::_1, boost::none)),
+                                factor, std::placeholders::_1, {})),
                             q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testGaussianPriorWorkspacePosition.cpp
+++ b/gpmp2/kinematics/tests/testGaussianPriorWorkspacePosition.cpp
@@ -37,12 +37,12 @@ TEST(GaussianPriorWorkspacePositionArm, error) {
     des_position = Point3(2, 0, 0);
     GaussianPriorWorkspacePositionArm factor(0, arm, 1, des_position,
                                              cost_model);
-    actual = factor.evaluateError(q, H_act);
+    actual = factor.evaluateError(q, &H_act);
     expect = Vector3(0, 0, 0);
     H_exp = numericalDerivative11(
         std::function<Vector3(const Vector2&)>(
             std::bind(&GaussianPriorWorkspacePositionArm::evaluateError, factor,
-                      std::placeholders::_1, {})),
+                      std::placeholders::_1, nullptr)),
         q, 1e-6);
     EXPECT(assert_equal(expect, actual, 1e-6));
     EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -54,7 +54,7 @@ TEST(GaussianPriorWorkspacePositionArm, error) {
     des_position = Point3(1.414213562373095, 1.414213562373095, 0);
     GaussianPriorWorkspacePositionArm factor(0, arm, 1, des_position,
                                              cost_model);
-    actual = factor.evaluateError(q, H_act);
+    actual = factor.evaluateError(q, &H_act);
     expect = Vector3(0, 0, 0);
     H_exp = numericalDerivative11(
         std::function<Vector3(const Vector2&)>(
@@ -71,7 +71,7 @@ TEST(GaussianPriorWorkspacePositionArm, error) {
     des_position = Point3(2, 0, 0);
     GaussianPriorWorkspacePositionArm factor(0, arm, 1, des_position,
                                              cost_model);
-    actual = factor.evaluateError(q, H_act);
+    actual = factor.evaluateError(q, &H_act);
     expect = Vector3(-0.585786437626905, 1.414213562373095, 0);
     H_exp = numericalDerivative11(
         std::function<Vector3(const Vector2&)>(

--- a/gpmp2/kinematics/tests/testGaussianPriorWorkspacePosition.cpp
+++ b/gpmp2/kinematics/tests/testGaussianPriorWorkspacePosition.cpp
@@ -42,7 +42,7 @@ TEST(GaussianPriorWorkspacePositionArm, error) {
     H_exp = numericalDerivative11(
         std::function<Vector3(const Vector2&)>(
             std::bind(&GaussianPriorWorkspacePositionArm::evaluateError, factor,
-                      std::placeholders::_1, boost::none)),
+                      std::placeholders::_1, {})),
         q, 1e-6);
     EXPECT(assert_equal(expect, actual, 1e-6));
     EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -59,7 +59,7 @@ TEST(GaussianPriorWorkspacePositionArm, error) {
     H_exp = numericalDerivative11(
         std::function<Vector3(const Vector2&)>(
             std::bind(&GaussianPriorWorkspacePositionArm::evaluateError, factor,
-                      std::placeholders::_1, boost::none)),
+                      std::placeholders::_1, nullptr)),
         q, 1e-6);
     EXPECT(assert_equal(expect, actual, 1e-6));
     EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -76,7 +76,7 @@ TEST(GaussianPriorWorkspacePositionArm, error) {
     H_exp = numericalDerivative11(
         std::function<Vector3(const Vector2&)>(
             std::bind(&GaussianPriorWorkspacePositionArm::evaluateError, factor,
-                      std::placeholders::_1, boost::none)),
+                      std::placeholders::_1, nullptr)),
         q, 1e-6);
     EXPECT(assert_equal(expect, actual, 1e-6));
     EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testGoalFactorArm.cpp
+++ b/gpmp2/kinematics/tests/testGoalFactorArm.cpp
@@ -39,7 +39,7 @@ TEST(GoalFactorArm, error) {
   q = Vector2(0, 0);
   goal = Point3(2, 0, 0);
   factor = GoalFactorArm(0, cost_model, arm, goal);
-  actual = factor.evaluateError(q, H_act);
+  actual = factor.evaluateError(q, &H_act);
   expect = Vector3(0, 0, 0);
   H_exp =
       numericalDerivative11(std::function<Vector3(const Vector2&)>(
@@ -53,7 +53,7 @@ TEST(GoalFactorArm, error) {
   q = Vector2(M_PI / 4.0, 0);
   goal = Point3(1.414213562373095, 1.414213562373095, 0);
   factor = GoalFactorArm(0, cost_model, arm, goal);
-  actual = factor.evaluateError(q, H_act);
+  actual = factor.evaluateError(q, &H_act);
   expect = Vector3(0, 0, 0);
   H_exp =
       numericalDerivative11(std::function<Vector3(const Vector2&)>(
@@ -67,7 +67,7 @@ TEST(GoalFactorArm, error) {
   q = Vector2(M_PI / 4.0, 0);
   goal = Point3(2, 0, 0);
   factor = GoalFactorArm(0, cost_model, arm, goal);
-  actual = factor.evaluateError(q, H_act);
+  actual = factor.evaluateError(q, &H_act);
   expect = Vector3(-0.585786437626905, 1.414213562373095, 0);
   H_exp =
       numericalDerivative11(std::function<Vector3(const Vector2&)>(

--- a/gpmp2/kinematics/tests/testGoalFactorArm.cpp
+++ b/gpmp2/kinematics/tests/testGoalFactorArm.cpp
@@ -44,7 +44,7 @@ TEST(GoalFactorArm, error) {
   H_exp =
       numericalDerivative11(std::function<Vector3(const Vector2&)>(
                                 std::bind(&GoalFactorArm::evaluateError, factor,
-                                          std::placeholders::_1, boost::none)),
+                                          std::placeholders::_1, nullptr)),
                             q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -58,7 +58,7 @@ TEST(GoalFactorArm, error) {
   H_exp =
       numericalDerivative11(std::function<Vector3(const Vector2&)>(
                                 std::bind(&GoalFactorArm::evaluateError, factor,
-                                          std::placeholders::_1, boost::none)),
+                                          std::placeholders::_1, nullptr)),
                             q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -72,7 +72,7 @@ TEST(GoalFactorArm, error) {
   H_exp =
       numericalDerivative11(std::function<Vector3(const Vector2&)>(
                                 std::bind(&GoalFactorArm::evaluateError, factor,
-                                          std::placeholders::_1, boost::none)),
+                                          std::placeholders::_1, nullptr)),
                             q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testJointLimitFactorPose2Vector.cpp
+++ b/gpmp2/kinematics/tests/testJointLimitFactorPose2Vector.cpp
@@ -40,7 +40,7 @@ TEST(JointLimitFactorPose2Vector, error) {
   H_exp = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&JointLimitFactorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, boost::none)),
+                    std::placeholders::_1, nullptr)),
       conf, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -52,7 +52,7 @@ TEST(JointLimitFactorPose2Vector, error) {
   H_exp = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&JointLimitFactorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, boost::none)),
+                    std::placeholders::_1, nullptr)),
       conf, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -64,7 +64,7 @@ TEST(JointLimitFactorPose2Vector, error) {
   H_exp = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
           std::bind(&JointLimitFactorPose2Vector::evaluateError, factor,
-                    std::placeholders::_1, boost::none)),
+                    std::placeholders::_1, nullptr)),
       conf, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testJointLimitFactorPose2Vector.cpp
+++ b/gpmp2/kinematics/tests/testJointLimitFactorPose2Vector.cpp
@@ -35,7 +35,7 @@ TEST(JointLimitFactorPose2Vector, error) {
 
   // zero
   conf = Pose2Vector(Pose2(), Vector2(0.0, 0.0));
-  actual = factor.evaluateError(conf, H_act);
+  actual = factor.evaluateError(conf, &H_act);
   expect = (Vector5() << 0, 0, 0, 0.0, 0.0).finished();
   H_exp = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
@@ -47,7 +47,7 @@ TEST(JointLimitFactorPose2Vector, error) {
 
   // over down limit
   conf = Pose2Vector(Pose2(), Vector2(-10.0, -10.0));
-  actual = factor.evaluateError(conf, H_act);
+  actual = factor.evaluateError(conf, &H_act);
   expect = (Vector5() << 0, 0, 0, 7.0, 2.0).finished();
   H_exp = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(
@@ -59,7 +59,7 @@ TEST(JointLimitFactorPose2Vector, error) {
 
   // over up limit
   conf = Pose2Vector(Pose2(), Vector2(10.0, 10.0));
-  actual = factor.evaluateError(conf, H_act);
+  actual = factor.evaluateError(conf, &H_act);
   expect = (Vector5() << 0, 0, 0, 7.0, 2.0).finished();
   H_exp = numericalDerivativeDynamic(
       std::function<Vector(const Pose2Vector&)>(

--- a/gpmp2/kinematics/tests/testJointLimitFactorVector.cpp
+++ b/gpmp2/kinematics/tests/testJointLimitFactorVector.cpp
@@ -39,7 +39,7 @@ TEST(JointLimitFactorVector, error) {
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector2&)>(std::bind(
                                 &JointLimitFactorVector::evaluateError, factor,
-                                std::placeholders::_1, boost::none)),
+                                std::placeholders::_1, nullptr)),
                             conf, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -51,7 +51,7 @@ TEST(JointLimitFactorVector, error) {
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector2&)>(std::bind(
                                 &JointLimitFactorVector::evaluateError, factor,
-                                std::placeholders::_1, boost::none)),
+                                std::placeholders::_1, nullptr)),
                             conf, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));
@@ -63,7 +63,7 @@ TEST(JointLimitFactorVector, error) {
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector2&)>(std::bind(
                                 &JointLimitFactorVector::evaluateError, factor,
-                                std::placeholders::_1, boost::none)),
+                                std::placeholders::_1, nullptr)),
                             conf, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/kinematics/tests/testJointLimitFactorVector.cpp
+++ b/gpmp2/kinematics/tests/testJointLimitFactorVector.cpp
@@ -34,7 +34,7 @@ TEST(JointLimitFactorVector, error) {
 
   // zero
   conf = Vector2(0.0, 0.0);
-  actual = factor.evaluateError(conf, H_act);
+  actual = factor.evaluateError(conf, &H_act);
   expect = Vector2(0.0, 0.0);
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector2&)>(std::bind(
@@ -46,7 +46,7 @@ TEST(JointLimitFactorVector, error) {
 
   // over down limit
   conf = Vector2(-10.0, -10.0);
-  actual = factor.evaluateError(conf, H_act);
+  actual = factor.evaluateError(conf, &H_act);
   expect = Vector2(7.0, 2.0);
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector2&)>(std::bind(
@@ -58,7 +58,7 @@ TEST(JointLimitFactorVector, error) {
 
   // over up limit
   conf = Vector2(10.0, 10.0);
-  actual = factor.evaluateError(conf, H_act);
+  actual = factor.evaluateError(conf, &H_act);
   expect = Vector2(7.0, 2.0);
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector2&)>(std::bind(

--- a/gpmp2/kinematics/tests/testMobileBaseUtils.cpp
+++ b/gpmp2/kinematics/tests/testMobileBaseUtils.cpp
@@ -29,22 +29,20 @@ TEST(mobileBaseUtils, computeBaseTransPose3) {
   p2 = Pose2();
   pexp = Pose3();
   pact = computeBaseTransPose3(p2, base_T_arm, Hact);
-  Hexp =
-      numericalDerivative11(std::function<Pose3(const Pose2&)>(std::bind(
-                                &computeBaseTransPose3, std::placeholders::_1,
-                                base_T_arm, boost::none)),
-                            p2, 1e-6);
+  Hexp = numericalDerivative11(
+      std::function<Pose3(const Pose2&)>(std::bind(
+          &computeBaseTransPose3, std::placeholders::_1, base_T_arm, nullptr)),
+      p2, 1e-6);
   EXPECT(assert_equal(pexp, pact, 1e-9));
   EXPECT(assert_equal(Hexp, Hact, 1e-6));
 
   p2 = Pose2(1.3, 4.5, -0.3);
   pexp = Pose3(Rot3::Yaw(-0.3), Point3(1.3, 4.5, 0));
   pact = computeBaseTransPose3(p2, base_T_arm, Hact);
-  Hexp =
-      numericalDerivative11(std::function<Pose3(const Pose2&)>(std::bind(
-                                &computeBaseTransPose3, std::placeholders::_1,
-                                base_T_arm, boost::none)),
-                            p2, 1e-6);
+  Hexp = numericalDerivative11(
+      std::function<Pose3(const Pose2&)>(std::bind(
+          &computeBaseTransPose3, std::placeholders::_1, base_T_arm, nullptr)),
+      p2, 1e-6);
   EXPECT(assert_equal(pexp, pact, 1e-9));
   EXPECT(assert_equal(Hexp, Hact, 1e-6));
 
@@ -54,22 +52,20 @@ TEST(mobileBaseUtils, computeBaseTransPose3) {
   p2 = Pose2();
   pexp = Pose3(Rot3::Yaw(-0.3), Point3(1, 1, 2));
   pact = computeBaseTransPose3(p2, base_T_arm, Hact);
-  Hexp =
-      numericalDerivative11(std::function<Pose3(const Pose2&)>(std::bind(
-                                &computeBaseTransPose3, std::placeholders::_1,
-                                base_T_arm, boost::none)),
-                            p2, 1e-6);
+  Hexp = numericalDerivative11(
+      std::function<Pose3(const Pose2&)>(std::bind(
+          &computeBaseTransPose3, std::placeholders::_1, base_T_arm, nullptr)),
+      p2, 1e-6);
   EXPECT(assert_equal(pexp, pact, 1e-9));
   EXPECT(assert_equal(Hexp, Hact, 1e-6));
 
   p2 = Pose2(2, -2, M_PI_2);
   pexp = Pose3(Rot3::Yaw(M_PI_2 - 0.3), Point3(1, -1, 2));
   pact = computeBaseTransPose3(p2, base_T_arm, Hact);
-  Hexp =
-      numericalDerivative11(std::function<Pose3(const Pose2&)>(std::bind(
-                                &computeBaseTransPose3, std::placeholders::_1,
-                                base_T_arm, boost::none)),
-                            p2, 1e-6);
+  Hexp = numericalDerivative11(
+      std::function<Pose3(const Pose2&)>(std::bind(
+          &computeBaseTransPose3, std::placeholders::_1, base_T_arm, nullptr)),
+      p2, 1e-6);
   EXPECT(assert_equal(pexp, pact, 1e-9));
   EXPECT(assert_equal(Hexp, Hact, 1e-6));
 }

--- a/gpmp2/kinematics/tests/testPointRobotModel.cpp
+++ b/gpmp2/kinematics/tests/testPointRobotModel.cpp
@@ -20,7 +20,7 @@ Pose3 fkpose(const PointRobot& pR, const Vector& jp, const Vector& jv,
              size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  pR.forwardKinematics(jp, jv, pos, vel);
+  pR.forwardKinematics(jp, jv, pos, &vel);
   return pos[i];
 }
 
@@ -28,7 +28,7 @@ Vector3 fkvelocity(const PointRobot& pR, const Vector& jp, const Vector& jv,
                    size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  pR.forwardKinematics(jp, jv, pos, vel);
+  pR.forwardKinematics(jp, jv, pos, &vel);
   return vel[i];
 }
 
@@ -59,7 +59,8 @@ TEST(PointRobot, 2DExample) {
   p = Vector2(1.0, 2.0);
   v = Vector2(0.1, 0.2);
   Vector vdymc = Vector(v);
-  pR.forwardKinematics(p, vdymc, pvec_act, vvec_act, pJp_act, vJp_act, vJv_act);
+  pR.forwardKinematics(p, vdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+                       &vJv_act);
 
   pvec_exp.clear();
   pvec_exp.push_back(Pose3(Rot3(), Point3(p(0), p(1), 0)));
@@ -111,7 +112,7 @@ TEST(PointRobotModel, 2DExample) {
   sph_centers_exp.clear();
   sph_centers_exp.push_back(Point3(1, 2, 0));
 
-  pR_model.sphereCenters(p, sph_centers_act, J_center_q_act);
+  pR_model.sphereCenters(p, sph_centers_act, &J_center_q_act);
 
   for (size_t i = 0; i < nr_sph; i++) {
     EXPECT(assert_equal(sph_centers_exp[i], sph_centers_act[i]));
@@ -121,7 +122,7 @@ TEST(PointRobotModel, 2DExample) {
         p, 1e-6);
     EXPECT(assert_equal(Jcq_exp, J_center_q_act[i], 1e-9));
     EXPECT(
-        assert_equal(sph_centers_exp[i], pR_model.sphereCenter(i, p, Jcq_act)));
+        assert_equal(sph_centers_exp[i], pR_model.sphereCenter(i, p, &Jcq_act)));
     Jcq_exp = numericalDerivative11(
         std::function<Point3(const Vector2&)>(std::bind(
             &sph_pos_wrapper_single, pR_model, std::placeholders::_1, i)),

--- a/gpmp2/kinematics/tests/testPose2Mobile2Arms.cpp
+++ b/gpmp2/kinematics/tests/testPose2Mobile2Arms.cpp
@@ -21,7 +21,7 @@ using namespace gpmp2;
 // fk wrapper
 Pose3 fkpose(const Pose2Mobile2Arms& r, const Pose2Vector& p, size_t i) {
   vector<Pose3> pos;
-  r.forwardKinematics(p, {}, pos, {});
+  r.forwardKinematics(p, {}, pos);
   return pos[i];
 }
 
@@ -75,7 +75,7 @@ TEST(Pose2Mobile2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(4))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -121,7 +121,7 @@ TEST(Pose2Mobile2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(4))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -162,7 +162,7 @@ TEST(Pose2Mobile2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(4))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2Mobile2Arms.cpp
+++ b/gpmp2/kinematics/tests/testPose2Mobile2Arms.cpp
@@ -21,7 +21,7 @@ using namespace gpmp2;
 // fk wrapper
 Pose3 fkpose(const Pose2Mobile2Arms& r, const Pose2Vector& p, size_t i) {
   vector<Pose3> pos;
-  r.forwardKinematics(p, boost::none, pos, boost::none);
+  r.forwardKinematics(p, {}, pos, {});
   return pos[i];
 }
 
@@ -75,7 +75,7 @@ TEST(Pose2Mobile2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(4))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -121,7 +121,7 @@ TEST(Pose2Mobile2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(4))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -162,7 +162,7 @@ TEST(Pose2Mobile2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(4))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileArm.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileArm.cpp
@@ -23,7 +23,7 @@ Pose3 fkpose(const Pose2MobileArm& r, const Pose2Vector& p, const Vector& v,
              size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  r.forwardKinematics(p, {}, pos, {});
+  r.forwardKinematics(p, {}, pos);
   return pos[i];
 }
 
@@ -31,7 +31,7 @@ Vector3 fkvelocity(const Pose2MobileArm& r, const Pose2Vector& p,
                    const Vector& v, size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  r.forwardKinematics(p, v, pos, vel);
+  r.forwardKinematics(p, v, pos, &vel);
   return vel[i];
 }
 
@@ -99,9 +99,9 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
     Vector5&)>( std::bind(&fkvelocity, marm, q, std::placeholders::_1,
     size_t(2))), qdot, 1e-6));
   */
-  // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
+  // marm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -174,7 +174,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -245,9 +245,9 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
     Vector5&)>( std::bind(&fkvelocity, marm, q, std::placeholders::_1,
     size_t(2))), qdot, 1e-6));
   */
-  // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
+  // marm.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -318,7 +318,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -389,7 +389,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -452,7 +452,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
 
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileArm.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileArm.cpp
@@ -23,7 +23,7 @@ Pose3 fkpose(const Pose2MobileArm& r, const Pose2Vector& p, const Vector& v,
              size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  r.forwardKinematics(p, boost::none, pos, boost::none);
+  r.forwardKinematics(p, {}, pos, {});
   return pos[i];
 }
 
@@ -101,7 +101,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -174,7 +174,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -247,7 +247,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -318,7 +318,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -389,7 +389,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
 
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
@@ -452,7 +452,7 @@ TEST(Pose2MobileArm, 2linkPlanarExamples) {
   */
   // marm.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
 
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileBase.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileBase.cpp
@@ -21,14 +21,14 @@ using namespace gpmp2;
 // fk wrapper
 Pose3 fkpose(const Pose2MobileBase& r, const Pose2& p, const Vector& v) {
   vector<Pose3> pos;
-  r.forwardKinematics(p, {}, pos, {});
+  r.forwardKinematics(p, {}, pos);
   return pos[0];
 }
 
 Vector3 fkvelocity(const Pose2MobileBase& r, const Pose2& p, const Vector& v) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  r.forwardKinematics(p, v, pos, vel);
+  r.forwardKinematics(p, v, pos, &vel);
   return vel[0];
 }
 
@@ -64,9 +64,9 @@ TEST(Pose2MobileBase, Example) {
   // vJv_exp.push_back(numericalDerivativeDynamic(std::function<Vector3(const
   // Vector3&)>(
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
-  // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
+  // robot.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -94,9 +94,9 @@ TEST(Pose2MobileBase, Example) {
   // vJv_exp.push_back(numericalDerivativeDynamic(std::function<Vector3(const
   // Vector3&)>(
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
-  // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-  // vJv_act);
-  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  // robot.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+  // &vJv_act);
+  robot.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -124,9 +124,9 @@ TEST(Pose2MobileBase, Example) {
   // vJv_exp.push_back(numericalDerivativeDynamic(std::function<Vector3(const
   // Vector3&)>(
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
-  // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-  // vJv_act);
-  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  // robot.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+  // &vJv_act);
+  robot.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -154,9 +154,9 @@ TEST(Pose2MobileBase, Example) {
   // vJv_exp.push_back(numericalDerivativeDynamic(std::function<Vector3(const
   // Vector3&)>(
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
-  // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
+  // robot.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -180,9 +180,9 @@ TEST(Pose2MobileBase, Example) {
   // vJv_exp.push_back(numericalDerivativeDynamic(std::function<Vector3(const
   // Vector3&)>(
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
-  // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
-  // vJv_act);
-  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  // robot.forwardKinematics(q, qdymc, pvec_act, &vvec_act, &pJp_act, &vJp_act,
+  // &vJv_act);
+  robot.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   // EXPECT(assert_equal(vJp_exp[0], vJp_act[0], 1e-6));
   // EXPECT(assert_equal(vJv_exp[0], vJv_act[0], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileBase.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileBase.cpp
@@ -21,7 +21,7 @@ using namespace gpmp2;
 // fk wrapper
 Pose3 fkpose(const Pose2MobileBase& r, const Pose2& p, const Vector& v) {
   vector<Pose3> pos;
-  r.forwardKinematics(p, boost::none, pos, boost::none);
+  r.forwardKinematics(p, {}, pos, {});
   return pos[0];
 }
 
@@ -66,7 +66,7 @@ TEST(Pose2MobileBase, Example) {
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
   // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -96,7 +96,7 @@ TEST(Pose2MobileBase, Example) {
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
   // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -126,7 +126,7 @@ TEST(Pose2MobileBase, Example) {
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
   // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -156,7 +156,7 @@ TEST(Pose2MobileBase, Example) {
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
   // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   // EXPECT(assert_equal(vvec_exp[0], vvec_act[0], 1e-9));
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
@@ -182,7 +182,7 @@ TEST(Pose2MobileBase, Example) {
   //     std::bind(&fkvelocity, robot, q, std::placeholders::_1)), qdot, 1e-6));
   // robot.forwardKinematics(q, qdymc, pvec_act, vvec_act, pJp_act, vJp_act,
   // vJv_act);
-  robot.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  robot.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   // EXPECT(assert_equal(vJp_exp[0], vJp_act[0], 1e-6));
   // EXPECT(assert_equal(vJv_exp[0], vJv_act[0], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileVetLin2Arms.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileVetLin2Arms.cpp
@@ -21,7 +21,7 @@ using namespace gpmp2;
 // fk wrapper
 Pose3 fkpose(const Pose2MobileVetLin2Arms& r, const Pose2Vector& p, size_t i) {
   vector<Pose3> pos;
-  r.forwardKinematics(p, boost::none, pos, boost::none);
+  r.forwardKinematics(p, {}, pos, {});
   return pos[i];
 }
 
@@ -80,7 +80,7 @@ TEST(Pose2MobileVetLin2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(5))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -135,7 +135,7 @@ TEST(Pose2MobileVetLin2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(5))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -184,7 +184,7 @@ TEST(Pose2MobileVetLin2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(5))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileVetLin2Arms.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileVetLin2Arms.cpp
@@ -21,7 +21,7 @@ using namespace gpmp2;
 // fk wrapper
 Pose3 fkpose(const Pose2MobileVetLin2Arms& r, const Pose2Vector& p, size_t i) {
   vector<Pose3> pos;
-  r.forwardKinematics(p, {}, pos, {});
+  r.forwardKinematics(p, {}, pos);
   return pos[i];
 }
 
@@ -80,7 +80,7 @@ TEST(Pose2MobileVetLin2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(5))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -135,7 +135,7 @@ TEST(Pose2MobileVetLin2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(5))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -184,7 +184,7 @@ TEST(Pose2MobileVetLin2Arms, 2linkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(5))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileVetLinArm.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileVetLinArm.cpp
@@ -22,7 +22,7 @@ using namespace gpmp2;
 Pose3 fkpose(const Pose2MobileVetLinArm& r, const Pose2Vector& p, size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  r.forwardKinematics(p, {}, pos, {});
+  r.forwardKinematics(p, {}, pos);
   return pos[i];
 }
 
@@ -68,7 +68,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -104,7 +104,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -139,7 +139,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));
@@ -166,7 +166,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, nullptr, &pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));

--- a/gpmp2/kinematics/tests/testPose2MobileVetLinArm.cpp
+++ b/gpmp2/kinematics/tests/testPose2MobileVetLinArm.cpp
@@ -22,7 +22,7 @@ using namespace gpmp2;
 Pose3 fkpose(const Pose2MobileVetLinArm& r, const Pose2Vector& p, size_t i) {
   vector<Pose3> pos;
   vector<Vector3> vel;
-  r.forwardKinematics(p, boost::none, pos, boost::none);
+  r.forwardKinematics(p, {}, pos, {});
   return pos[i];
 }
 
@@ -68,7 +68,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -104,7 +104,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pvec_exp[0], pvec_act[0], 1e-9));
   EXPECT(assert_equal(pvec_exp[1], pvec_act[1], 1e-9));
   EXPECT(assert_equal(pvec_exp[2], pvec_act[2], 1e-9));
@@ -139,7 +139,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));
@@ -166,7 +166,7 @@ TEST(Pose2MobileVetLinArm, TwoLinkPlanarExamples) {
       std::function<Pose3(const Pose2Vector&)>(
           std::bind(&fkpose, marm, std::placeholders::_1, size_t(3))),
       q, 1e-6));
-  marm.forwardKinematics(q, boost::none, pvec_act, boost::none, pJp_act);
+  marm.forwardKinematics(q, {}, pvec_act, {}, pJp_act);
   EXPECT(assert_equal(pJp_exp[0], pJp_act[0], 1e-6));
   EXPECT(assert_equal(pJp_exp[1], pJp_act[1], 1e-6));
   EXPECT(assert_equal(pJp_exp[2], pJp_act[2], 1e-6));

--- a/gpmp2/obstacle/ObstacleCost.h
+++ b/gpmp2/obstacle/ObstacleCost.h
@@ -22,7 +22,7 @@ namespace gpmp2 {
 /// hinge loss obstacle cost function
 inline double hingeLossObstacleCost(
     const gtsam::Point3& point, const SignedDistanceField& sdf, double eps,
-    gtsam::OptionalJacobian<1, 3> H_point = boost::none) {
+    gtsam::OptionalJacobian<1, 3> H_point = nullptr) {
   gtsam::Vector3 field_gradient;
   double dist_signed;
   try {
@@ -50,7 +50,7 @@ inline double hingeLossObstacleCost(
 /// hinge loss obstacle cost function, planar version
 inline double hingeLossObstacleCost(
     const gtsam::Point2& point, const PlanarSDF& sdf, double eps,
-    gtsam::OptionalJacobian<1, 2> H_point = boost::none) {
+    gtsam::OptionalJacobian<1, 2> H_point = nullptr) {
   gtsam::Vector2 field_gradient;
   double dist_signed;
   try {

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactor-inl.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactor-inl.h
@@ -15,7 +15,7 @@ namespace gpmp2 {
 /* ************************************************************************** */
 template <class ROBOT>
 gtsam::Vector ObstaclePlanarSDFFactor<ROBOT>::evaluateError(
-    const Pose& conf, std::optional<gtsam::Matrix> H1) const {
+    const Pose& conf, gtsam::OptionalMatrixType H1) const {
   // if Jacobians used, initialize as zeros
   // size: arm_nr_points_ * DOF
   if (H1) *H1 = Matrix::Zero(robot_.nr_body_spheres(), robot_.dof());
@@ -24,7 +24,7 @@ gtsam::Vector ObstaclePlanarSDFFactor<ROBOT>::evaluateError(
   vector<Point3> sph_centers;
   vector<Matrix> J_px_jp;
   if (H1)
-    robot_.sphereCenters(conf, sph_centers, J_px_jp);
+    robot_.sphereCenters(conf, sph_centers, &J_px_jp);
   else
     robot_.sphereCenters(conf, sph_centers);
 

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactor-inl.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactor-inl.h
@@ -15,7 +15,7 @@ namespace gpmp2 {
 /* ************************************************************************** */
 template <class ROBOT>
 gtsam::Vector ObstaclePlanarSDFFactor<ROBOT>::evaluateError(
-    const Pose& conf, boost::optional<gtsam::Matrix&> H1) const {
+    const Pose& conf, std::optional<gtsam::Matrix> H1) const {
   // if Jacobians used, initialize as zeros
   // size: arm_nr_points_ * DOF
   if (H1) *H1 = Matrix::Zero(robot_.nr_body_spheres(), robot_.dof());

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactor.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactor.h
@@ -24,7 +24,7 @@ namespace gpmp2 {
  */
 template <class ROBOT>
 class ObstaclePlanarSDFFactor
-    : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
+    : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
  public:
   // typedefs
   using Robot = ROBOT;
@@ -33,7 +33,7 @@ class ObstaclePlanarSDFFactor
  private:
   // typedefs
   typedef ObstaclePlanarSDFFactor This;
-  typedef gtsam::NoiseModelFactor1<Pose> Base;
+  typedef gtsam::NoiseModelFactorN<Pose> Base;
 
   // obstacle cost settings
   double epsilon_;  // distance from object that start non-zero cost
@@ -73,8 +73,8 @@ class ObstaclePlanarSDFFactor
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(const Pose& conf,
-                              std::optional<gtsam::Matrix> H1 = {}) const;
+  gtsam::Vector evaluateError(
+      const Pose& conf, gtsam::OptionalMatrixType H1 = nullptr) const override;
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactor.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactor.h
@@ -46,7 +46,7 @@ class ObstaclePlanarSDFFactor
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /** Default constructor */
   ObstaclePlanarSDFFactor() {}
@@ -73,12 +73,12 @@ class ObstaclePlanarSDFFactor
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(
-      const Pose& conf, boost::optional<gtsam::Matrix&> H1 = boost::none) const;
+  gtsam::Vector evaluateError(const Pose& conf,
+                              std::optional<gtsam::Matrix> H1 = {}) const;
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactor.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactor.h
@@ -90,6 +90,7 @@ class ObstaclePlanarSDFFactor
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -97,6 +98,7 @@ class ObstaclePlanarSDFFactor
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactorGP-inl.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactorGP-inl.h
@@ -18,9 +18,9 @@ namespace gpmp2 {
 template <class ROBOT, class GPINTER>
 gtsam::Vector ObstaclePlanarSDFFactorGP<ROBOT, GPINTER>::evaluateError(
     const Pose& conf1, const Velocity& vel1, const Pose& conf2,
-    const Velocity& vel2, std::optional<gtsam::Matrix> H1,
-    std::optional<gtsam::Matrix> H2, std::optional<gtsam::Matrix> H3,
-    std::optional<gtsam::Matrix> H4) const {
+    const Velocity& vel2, gtsam::OptionalMatrixType H1,
+    gtsam::OptionalMatrixType H2, gtsam::OptionalMatrixType H3,
+    gtsam::OptionalMatrixType H4) const {
   const bool use_H = (H1 || H2 || H3 || H4);
 
   // if Jacobians used, initialize Jerr_conf as zeros
@@ -40,7 +40,7 @@ gtsam::Vector ObstaclePlanarSDFFactorGP<ROBOT, GPINTER>::evaluateError(
   vector<Point3> sph_centers;
   vector<Matrix> J_px_jp;
   if (H1)
-    robot_.sphereCenters(conf, sph_centers, J_px_jp);
+    robot_.sphereCenters(conf, sph_centers, &J_px_jp);
   else
     robot_.sphereCenters(conf, sph_centers);
 

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactorGP-inl.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactorGP-inl.h
@@ -18,9 +18,9 @@ namespace gpmp2 {
 template <class ROBOT, class GPINTER>
 gtsam::Vector ObstaclePlanarSDFFactorGP<ROBOT, GPINTER>::evaluateError(
     const Pose& conf1, const Velocity& vel1, const Pose& conf2,
-    const Velocity& vel2, boost::optional<gtsam::Matrix&> H1,
-    boost::optional<gtsam::Matrix&> H2, boost::optional<gtsam::Matrix&> H3,
-    boost::optional<gtsam::Matrix&> H4) const {
+    const Velocity& vel2, std::optional<gtsam::Matrix> H1,
+    std::optional<gtsam::Matrix> H2, std::optional<gtsam::Matrix> H3,
+    std::optional<gtsam::Matrix> H4) const {
   const bool use_H = (H1 || H2 || H3 || H4);
 
   // if Jacobians used, initialize Jerr_conf as zeros

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactorGP.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactorGP.h
@@ -53,7 +53,7 @@ class ObstaclePlanarSDFFactorGP
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   ObstaclePlanarSDFFactorGP() {}
@@ -89,16 +89,16 @@ class ObstaclePlanarSDFFactorGP
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(
-      const Pose& conf1, const Velocity& vel1, const Pose& conf2,
-      const Velocity& vel2, boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none,
-      boost::optional<gtsam::Matrix&> H3 = boost::none,
-      boost::optional<gtsam::Matrix&> H4 = boost::none) const;
+  gtsam::Vector evaluateError(const Pose& conf1, const Velocity& vel1,
+                              const Pose& conf2, const Velocity& vel2,
+                              std::optional<gtsam::Matrix> H1 = {},
+                              std::optional<gtsam::Matrix> H2 = {},
+                              std::optional<gtsam::Matrix> H3 = {},
+                              std::optional<gtsam::Matrix> H4 = {}) const;
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactorGP.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactorGP.h
@@ -24,7 +24,7 @@ namespace gpmp2 {
  */
 template <class ROBOT, class GPINTER>
 class ObstaclePlanarSDFFactorGP
-    : public gtsam::NoiseModelFactor4<
+    : public gtsam::NoiseModelFactorN<
           typename ROBOT::Pose, typename ROBOT::Velocity, typename ROBOT::Pose,
           typename ROBOT::Velocity> {
  public:
@@ -36,7 +36,7 @@ class ObstaclePlanarSDFFactorGP
  private:
   // typedefs
   typedef ObstaclePlanarSDFFactorGP This;
-  typedef gtsam::NoiseModelFactor4<Pose, Velocity, Pose, Velocity> Base;
+  typedef gtsam::NoiseModelFactorN<Pose, Velocity, Pose, Velocity> Base;
   typedef GPINTER GPBase;
 
   // GP interpolator
@@ -85,19 +85,19 @@ class ObstaclePlanarSDFFactorGP
     // TODO: check arm is plannar
   }
 
-  virtual ~ObstaclePlanarSDFFactorGP() {}
+  ~ObstaclePlanarSDFFactorGP() {}
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(const Pose& conf1, const Velocity& vel1,
-                              const Pose& conf2, const Velocity& vel2,
-                              std::optional<gtsam::Matrix> H1 = {},
-                              std::optional<gtsam::Matrix> H2 = {},
-                              std::optional<gtsam::Matrix> H3 = {},
-                              std::optional<gtsam::Matrix> H4 = {}) const;
+  gtsam::Vector evaluateError(
+      const Pose& conf1, const Velocity& vel1, const Pose& conf2,
+      const Velocity& vel2, gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr,
+      gtsam::OptionalMatrixType H4 = nullptr) const override;
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/obstacle/ObstaclePlanarSDFFactorGP.h
+++ b/gpmp2/obstacle/ObstaclePlanarSDFFactorGP.h
@@ -110,6 +110,7 @@ class ObstaclePlanarSDFFactorGP
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -117,6 +118,7 @@ class ObstaclePlanarSDFFactorGP
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/ObstacleSDFFactor-inl.h
+++ b/gpmp2/obstacle/ObstacleSDFFactor-inl.h
@@ -15,8 +15,7 @@ namespace gpmp2 {
 /* ************************************************************************** */
 template <class ROBOT>
 gtsam::Vector ObstacleSDFFactor<ROBOT>::evaluateError(
-    const typename Robot::Pose& conf,
-    boost::optional<gtsam::Matrix&> H1) const {
+    const typename Robot::Pose& conf, std::optional<gtsam::Matrix> H1) const {
   // if Jacobians used, initialize as zeros
   // size: arm_nr_points_ * DOF
   if (H1) *H1 = Matrix::Zero(robot_.nr_body_spheres(), robot_.dof());

--- a/gpmp2/obstacle/ObstacleSDFFactor-inl.h
+++ b/gpmp2/obstacle/ObstacleSDFFactor-inl.h
@@ -15,7 +15,7 @@ namespace gpmp2 {
 /* ************************************************************************** */
 template <class ROBOT>
 gtsam::Vector ObstacleSDFFactor<ROBOT>::evaluateError(
-    const typename Robot::Pose& conf, std::optional<gtsam::Matrix> H1) const {
+    const typename Robot::Pose& conf, gtsam::OptionalMatrixType H1) const {
   // if Jacobians used, initialize as zeros
   // size: arm_nr_points_ * DOF
   if (H1) *H1 = Matrix::Zero(robot_.nr_body_spheres(), robot_.dof());
@@ -24,7 +24,7 @@ gtsam::Vector ObstacleSDFFactor<ROBOT>::evaluateError(
   vector<Point3> sph_centers;
   vector<Matrix> J_px_jp;
   if (H1)
-    robot_.sphereCenters(conf, sph_centers, J_px_jp);
+    robot_.sphereCenters(conf, sph_centers, &J_px_jp);
   else
     robot_.sphereCenters(conf, sph_centers);
 

--- a/gpmp2/obstacle/ObstacleSDFFactor.h
+++ b/gpmp2/obstacle/ObstacleSDFFactor.h
@@ -24,7 +24,7 @@ namespace gpmp2 {
  */
 template <class ROBOT>
 class ObstacleSDFFactor
-    : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
+    : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
  public:
   // typedefs
   typedef ROBOT Robot;
@@ -33,7 +33,7 @@ class ObstacleSDFFactor
  private:
   // typedefs
   typedef ObstacleSDFFactor This;
-  typedef gtsam::NoiseModelFactor1<Pose> Base;
+  typedef gtsam::NoiseModelFactorN<Pose> Base;
 
   // obstacle cost settings
   double epsilon_;  // distance from object that start non-zero cost
@@ -71,8 +71,9 @@ class ObstacleSDFFactor
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(const typename Robot::Pose& conf,
-                              std::optional<gtsam::Matrix> H1 = {}) const;
+  gtsam::Vector evaluateError(
+      const typename Robot::Pose& conf,
+      gtsam::OptionalMatrixType H1 = nullptr) const override;
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {

--- a/gpmp2/obstacle/ObstacleSDFFactor.h
+++ b/gpmp2/obstacle/ObstacleSDFFactor.h
@@ -89,6 +89,7 @@ class ObstacleSDFFactor
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -96,6 +97,7 @@ class ObstacleSDFFactor
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/ObstacleSDFFactor.h
+++ b/gpmp2/obstacle/ObstacleSDFFactor.h
@@ -46,7 +46,7 @@ class ObstacleSDFFactor
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   ObstacleSDFFactor() {}
@@ -71,13 +71,12 @@ class ObstacleSDFFactor
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(
-      const typename Robot::Pose& conf,
-      boost::optional<gtsam::Matrix&> H1 = boost::none) const;
+  gtsam::Vector evaluateError(const typename Robot::Pose& conf,
+                              std::optional<gtsam::Matrix> H1 = {}) const;
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/obstacle/ObstacleSDFFactorGP-inl.h
+++ b/gpmp2/obstacle/ObstacleSDFFactorGP-inl.h
@@ -18,8 +18,8 @@ template <class ROBOT, class GPINTER>
 gtsam::Vector ObstacleSDFFactorGP<ROBOT, GPINTER>::evaluateError(
     const typename Robot::Pose& conf1, const typename Robot::Velocity& vel1,
     const typename Robot::Pose& conf2, const typename Robot::Velocity& vel2,
-    std::optional<gtsam::Matrix> H1, std::optional<gtsam::Matrix> H2,
-    std::optional<gtsam::Matrix> H3, std::optional<gtsam::Matrix> H4) const {
+    gtsam::OptionalMatrixType H1, gtsam::OptionalMatrixType H2,
+    gtsam::OptionalMatrixType H3, gtsam::OptionalMatrixType H4) const {
   const bool use_H = (H1 || H2 || H3 || H4);
 
   // if Jacobians used, initialize Jerr_conf as zeros
@@ -39,7 +39,7 @@ gtsam::Vector ObstacleSDFFactorGP<ROBOT, GPINTER>::evaluateError(
   vector<Point3> sph_centers;
   vector<Matrix> J_px_jp;
   if (H1)
-    robot_.sphereCenters(conf, sph_centers, J_px_jp);
+    robot_.sphereCenters(conf, sph_centers, &J_px_jp);
   else
     robot_.sphereCenters(conf, sph_centers);
 

--- a/gpmp2/obstacle/ObstacleSDFFactorGP-inl.h
+++ b/gpmp2/obstacle/ObstacleSDFFactorGP-inl.h
@@ -18,9 +18,8 @@ template <class ROBOT, class GPINTER>
 gtsam::Vector ObstacleSDFFactorGP<ROBOT, GPINTER>::evaluateError(
     const typename Robot::Pose& conf1, const typename Robot::Velocity& vel1,
     const typename Robot::Pose& conf2, const typename Robot::Velocity& vel2,
-    boost::optional<gtsam::Matrix&> H1, boost::optional<gtsam::Matrix&> H2,
-    boost::optional<gtsam::Matrix&> H3,
-    boost::optional<gtsam::Matrix&> H4) const {
+    std::optional<gtsam::Matrix> H1, std::optional<gtsam::Matrix> H2,
+    std::optional<gtsam::Matrix> H3, std::optional<gtsam::Matrix> H4) const {
   const bool use_H = (H1 || H2 || H3 || H4);
 
   // if Jacobians used, initialize Jerr_conf as zeros

--- a/gpmp2/obstacle/ObstacleSDFFactorGP.h
+++ b/gpmp2/obstacle/ObstacleSDFFactorGP.h
@@ -53,7 +53,7 @@ class ObstacleSDFFactorGP
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   ObstacleSDFFactorGP() {}
@@ -86,17 +86,18 @@ class ObstacleSDFFactorGP
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(
-      const typename Robot::Pose& conf1, const typename Robot::Velocity& vel1,
-      const typename Robot::Pose& conf2, const typename Robot::Velocity& vel2,
-      boost::optional<gtsam::Matrix&> H1 = boost::none,
-      boost::optional<gtsam::Matrix&> H2 = boost::none,
-      boost::optional<gtsam::Matrix&> H3 = boost::none,
-      boost::optional<gtsam::Matrix&> H4 = boost::none) const;
+  gtsam::Vector evaluateError(const typename Robot::Pose& conf1,
+                              const typename Robot::Velocity& vel1,
+                              const typename Robot::Pose& conf2,
+                              const typename Robot::Velocity& vel2,
+                              std::optional<gtsam::Matrix> H1 = {},
+                              std::optional<gtsam::Matrix> H2 = {},
+                              std::optional<gtsam::Matrix> H3 = {},
+                              std::optional<gtsam::Matrix> H4 = {}) const;
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/obstacle/ObstacleSDFFactorGP.h
+++ b/gpmp2/obstacle/ObstacleSDFFactorGP.h
@@ -24,7 +24,7 @@ namespace gpmp2 {
  */
 template <class ROBOT, class GPINTER>
 class ObstacleSDFFactorGP
-    : public gtsam::NoiseModelFactor4<
+    : public gtsam::NoiseModelFactorN<
           typename ROBOT::Pose, typename ROBOT::Velocity, typename ROBOT::Pose,
           typename ROBOT::Velocity> {
  public:
@@ -36,7 +36,7 @@ class ObstacleSDFFactorGP
  private:
   // typedefs
   typedef ObstacleSDFFactorGP This;
-  typedef gtsam::NoiseModelFactor4<Pose, Velocity, Pose, Velocity> Base;
+  typedef gtsam::NoiseModelFactorN<Pose, Velocity, Pose, Velocity> Base;
   typedef GPINTER GPBase;
 
   // GP interpolator
@@ -82,21 +82,20 @@ class ObstacleSDFFactorGP
         robot_(robot),
         sdf_(sdf) {}
 
-  virtual ~ObstacleSDFFactorGP() {}
+  ~ObstacleSDFFactorGP() {}
 
   /// error function
   /// numerical jacobians / analytic jacobians from cost function
-  gtsam::Vector evaluateError(const typename Robot::Pose& conf1,
-                              const typename Robot::Velocity& vel1,
-                              const typename Robot::Pose& conf2,
-                              const typename Robot::Velocity& vel2,
-                              std::optional<gtsam::Matrix> H1 = {},
-                              std::optional<gtsam::Matrix> H2 = {},
-                              std::optional<gtsam::Matrix> H3 = {},
-                              std::optional<gtsam::Matrix> H4 = {}) const;
+  gtsam::Vector evaluateError(
+      const typename Robot::Pose& conf1, const typename Robot::Velocity& vel1,
+      const typename Robot::Pose& conf2, const typename Robot::Velocity& vel2,
+      gtsam::OptionalMatrixType H1 = nullptr,
+      gtsam::OptionalMatrixType H2 = nullptr,
+      gtsam::OptionalMatrixType H3 = nullptr,
+      gtsam::OptionalMatrixType H4 = nullptr) const override;
 
   /// @return a deep copy of this factor
-  virtual gtsam::NonlinearFactor::shared_ptr clone() const {
+  gtsam::NonlinearFactor::shared_ptr clone() const override {
     return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }

--- a/gpmp2/obstacle/ObstacleSDFFactorGP.h
+++ b/gpmp2/obstacle/ObstacleSDFFactorGP.h
@@ -108,6 +108,7 @@ class ObstacleSDFFactorGP
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -115,6 +116,7 @@ class ObstacleSDFFactorGP
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor4", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/PlanarSDF.h
+++ b/gpmp2/obstacle/PlanarSDF.h
@@ -23,9 +23,9 @@ namespace gpmp2 {
 class GPMP2_EXPORT PlanarSDF {
  public:
   // index and float_index is <row, col>
-  typedef boost::tuple<size_t, size_t> index;
-  typedef boost::tuple<double, double> float_index;
-  typedef boost::shared_ptr<PlanarSDF> shared_ptr;
+  typedef std::tuple<size_t, size_t> index;
+  typedef std::tuple<double, double> float_index;
+  typedef std::shared_ptr<PlanarSDF> shared_ptr;
 
  private:
   gtsam::Point2 origin_;
@@ -77,27 +77,27 @@ class GPMP2_EXPORT PlanarSDF {
 
     const double col = (point.x() - origin_.x()) / cell_size_;
     const double row = (point.y() - origin_.y()) / cell_size_;
-    return boost::make_tuple(row, col);
+    return std::make_tuple(row, col);
   }
 
   inline gtsam::Point2 convertCelltoPoint2(const float_index& cell) const {
-    return origin_ + gtsam::Point2(cell.get<1>() * cell_size_,
-                                   cell.get<0>() * cell_size_);
+    return origin_ + gtsam::Point2(std::get<1>(cell) * cell_size_,
+                                   std::get<0>(cell) * cell_size_);
   }
 
   /// bilinear interpolation
   inline double signed_distance(const float_index& idx) const {
-    const double lr = floor(idx.get<0>()), lc = floor(idx.get<1>());
+    const double lr = floor(std::get<0>(idx)), lc = floor(std::get<1>(idx));
     const double hr = lr + 1.0, hc = lc + 1.0;
     const size_t lri = static_cast<size_t>(lr), lci = static_cast<size_t>(lc),
                  hri = static_cast<size_t>(hr), hci = static_cast<size_t>(hc);
-    return (hr - idx.get<0>()) * (hc - idx.get<1>()) *
+    return (hr - std::get<0>(idx)) * (hc - std::get<1>(idx)) *
                signed_distance(lri, lci) +
-           (idx.get<0>() - lr) * (hc - idx.get<1>()) *
+           (std::get<0>(idx) - lr) * (hc - std::get<1>(idx)) *
                signed_distance(hri, lci) +
-           (hr - idx.get<0>()) * (idx.get<1>() - lc) *
+           (hr - std::get<0>(idx)) * (std::get<1>(idx) - lc) *
                signed_distance(lri, hci) +
-           (idx.get<0>() - lr) * (idx.get<1>() - lc) *
+           (std::get<0>(idx) - lr) * (std::get<1>(idx) - lc) *
                signed_distance(hri, hci);
   }
 
@@ -105,19 +105,19 @@ class GPMP2_EXPORT PlanarSDF {
   /// gradient regrads to float_index
   /// not numerical differentiable at index point
   inline gtsam::Vector2 gradient(const float_index& idx) const {
-    const double lr = floor(idx.get<0>()), lc = floor(idx.get<1>());
+    const double lr = floor(std::get<0>(idx)), lc = floor(std::get<1>(idx));
     const double hr = lr + 1.0, hc = lc + 1.0;
     const size_t lri = static_cast<size_t>(lr), lci = static_cast<size_t>(lc),
                  hri = static_cast<size_t>(hr), hci = static_cast<size_t>(hc);
     return gtsam::Vector2(
-        (hc - idx.get<1>()) *
+        (hc - std::get<1>(idx)) *
                 (signed_distance(hri, lci) - signed_distance(lri, lci)) +
-            (idx.get<1>() - lc) *
+            (std::get<1>(idx) - lc) *
                 (signed_distance(hri, hci) - signed_distance(lri, hci)),
 
-        (hr - idx.get<0>()) *
+        (hr - std::get<0>(idx)) *
                 (signed_distance(lri, hci) - signed_distance(lri, lci)) +
-            (idx.get<0>() - lr) *
+            (std::get<0>(idx) - lr) *
                 (signed_distance(hri, hci) - signed_distance(hri, lci)));
   }
 

--- a/gpmp2/obstacle/SelfCollision.h
+++ b/gpmp2/obstacle/SelfCollision.h
@@ -47,7 +47,7 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
 
  public:
   /// shorthand for a smart pointer to a factor
-  typedef boost::shared_ptr<This> shared_ptr;
+  typedef std::shared_ptr<This> shared_ptr;
 
   /* Default constructor */
   SelfCollision() {}
@@ -61,9 +61,8 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
   virtual ~SelfCollision() {}
 
   /// error function
-  gtsam::Vector evaluateError(
-      const typename Robot::Pose& conf,
-      boost::optional<gtsam::Matrix&> H = boost::none) const {
+  gtsam::Vector evaluateError(const typename Robot::Pose& conf,
+                              std::optional<gtsam::Matrix> H = {}) const {
     gtsam::Vector error(data_.rows());
     if (H) {
       *H = gtsam::Matrix::Zero(data_.rows(), robot_.dof());
@@ -106,8 +105,8 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
 
   double hingeLossSelfCollisionCost(
       const gtsam::Point3& pointA, const gtsam::Point3& pointB, double eps,
-      gtsam::OptionalJacobian<1, 3> H_pointA = boost::none,
-      gtsam::OptionalJacobian<1, 3> H_pointB = boost::none) const {
+      gtsam::OptionalJacobian<1, 3> H_pointA = {},
+      gtsam::OptionalJacobian<1, 3> H_pointB = {}) const {
     gtsam::Matrix H_A, H_B;
     double dist = gtsam::distance3(pointA, pointB, H_A, H_B);
 
@@ -124,7 +123,7 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
 
   /// @return a deep copy of this factor
   virtual gtsam::NonlinearFactor::shared_ptr clone() const {
-    return boost::static_pointer_cast<gtsam::NonlinearFactor>(
+    return std::static_pointer_cast<gtsam::NonlinearFactor>(
         gtsam::NonlinearFactor::shared_ptr(new This(*this)));
   }
 

--- a/gpmp2/obstacle/SelfCollision.h
+++ b/gpmp2/obstacle/SelfCollision.h
@@ -136,6 +136,7 @@ class SelfCollision : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
     Base::print("", keyFormatter);
   }
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class ARCHIVE>
@@ -143,6 +144,7 @@ class SelfCollision : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
     ar& boost::serialization::make_nvp(
         "NoiseModelFactor1", boost::serialization::base_object<Base>(*this));
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/SelfCollision.h
+++ b/gpmp2/obstacle/SelfCollision.h
@@ -22,7 +22,7 @@ namespace gpmp2 {
  * template robot model version
  */
 template <class ROBOT>
-class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
+class SelfCollision : public gtsam::NoiseModelFactorN<typename ROBOT::Pose> {
  public:
   // typedefs
   typedef ROBOT Robot;
@@ -31,7 +31,7 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
  private:
   // typedefs
   typedef SelfCollision This;
-  typedef gtsam::NoiseModelFactor1<Pose> Base;
+  typedef gtsam::NoiseModelFactorN<Pose> Base;
 
   /** (N x 4) matrix of parameters
    * rows N : number of self collision checks
@@ -61,8 +61,9 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
   virtual ~SelfCollision() {}
 
   /// error function
-  gtsam::Vector evaluateError(const typename Robot::Pose& conf,
-                              std::optional<gtsam::Matrix> H = {}) const {
+  gtsam::Vector evaluateError(
+      const typename Robot::Pose& conf,
+      gtsam::OptionalMatrixType H = nullptr) const override {
     gtsam::Vector error(data_.rows());
     if (H) {
       *H = gtsam::Matrix::Zero(data_.rows(), robot_.dof());
@@ -72,7 +73,7 @@ class SelfCollision : public gtsam::NoiseModelFactor1<typename ROBOT::Pose> {
     std::vector<gtsam::Point3> sph_centers;
     std::vector<gtsam::Matrix> Hs_sph_conf;
     if (H) {
-      robot_.sphereCenters(conf, sph_centers, Hs_sph_conf);
+      robot_.sphereCenters(conf, sph_centers, &Hs_sph_conf);
     } else {
       robot_.sphereCenters(conf, sph_centers);
     }

--- a/gpmp2/obstacle/SignedDistanceField.cpp
+++ b/gpmp2/obstacle/SignedDistanceField.cpp
@@ -11,6 +11,7 @@ namespace gpmp2 {
 
 /* ************************************************************************** */
 void SignedDistanceField::saveSDF(const std::string filename) {
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   std::ofstream ofs(filename.c_str());
   assert(ofs.good());
   std::string fext = filename.substr(filename.find_last_of(".") + 1);
@@ -24,10 +25,15 @@ void SignedDistanceField::saveSDF(const std::string filename) {
     boost::archive::text_oarchive oa(ofs);
     oa << *this;
   }
+#else
+  std::cerr << "Cannot save SDF since Boost serialization is disabled"
+            << std::endl;
+#endif
 }
 
 /* ************************************************************************** */
 void SignedDistanceField::loadSDF(const std::string filename) {
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   std::ifstream ifs(filename.c_str());
   if (!ifs.good())
     std::cout << "File \'" << filename << "\' does not exist!" << std::endl;
@@ -42,6 +48,10 @@ void SignedDistanceField::loadSDF(const std::string filename) {
     boost::archive::text_iarchive ia(ifs);
     ia >> *this;
   }
+#else
+  std::cerr << "Cannot load SDF since Boost serialization is disabled"
+            << std::endl;
+#endif
 }
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/SignedDistanceField.h
+++ b/gpmp2/obstacle/SignedDistanceField.h
@@ -240,12 +240,12 @@ class GPMP2_EXPORT SignedDistanceField {
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /* version */) {
-    // ar& BOOST_SERIALIZATION_NVP(origin_);
-    // ar& BOOST_SERIALIZATION_NVP(field_rows_);
-    // ar& BOOST_SERIALIZATION_NVP(field_cols_);
-    // ar& BOOST_SERIALIZATION_NVP(field_z_);
-    // ar& BOOST_SERIALIZATION_NVP(cell_size_);
-    // ar& BOOST_SERIALIZATION_NVP(data_);
+    ar& BOOST_SERIALIZATION_NVP(origin_);
+    ar& BOOST_SERIALIZATION_NVP(field_rows_);
+    ar& BOOST_SERIALIZATION_NVP(field_cols_);
+    ar& BOOST_SERIALIZATION_NVP(field_z_);
+    ar& BOOST_SERIALIZATION_NVP(cell_size_);
+    ar& BOOST_SERIALIZATION_NVP(data_);
   }
 };
 

--- a/gpmp2/obstacle/SignedDistanceField.h
+++ b/gpmp2/obstacle/SignedDistanceField.h
@@ -14,6 +14,7 @@
 #include <gtsam/base/VectorSerialization.h>
 #include <gtsam/geometry/Point3.h>
 
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
@@ -21,7 +22,8 @@
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/tuple/tuple.hpp>
+#endif
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -236,6 +238,7 @@ class GPMP2_EXPORT SignedDistanceField {
   void loadSDF(const std::string filename);
 
  private:
+#ifdef GPMP2_ENABLE_BOOST_SERIALIZATION
   /** Serialization function */
   friend class boost::serialization::access;
   template <class Archive>
@@ -247,6 +250,7 @@ class GPMP2_EXPORT SignedDistanceField {
     ar& BOOST_SERIALIZATION_NVP(cell_size_);
     ar& BOOST_SERIALIZATION_NVP(data_);
   }
+#endif
 };
 
 }  // namespace gpmp2

--- a/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorArm.cpp
+++ b/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorArm.cpp
@@ -83,7 +83,7 @@ TEST_UNSAFE(ObstaclePlanarSDFFactorArm, error) {
 
   // origin zero case
   q = Vector2(0, 0);
-  err_act = factor.evaluateError(q, H1_act);
+  err_act = factor.evaluateError(q, &H1_act);
   sdf_exp = (Vector(4) << 1.662575, 0.60355, 0, 0).finished();
   err_exp = convertSDFtoErr(sdf_exp, obs_eps + r);
   H1_exp =
@@ -95,7 +95,7 @@ TEST_UNSAFE(ObstaclePlanarSDFFactorArm, error) {
 
   // 45 deg case
   q = Vector2(M_PI / 4.0, 0);
-  err_act = factor.evaluateError(q, H1_act);
+  err_act = factor.evaluateError(q, &H1_act);
   sdf_exp = (Vector(4) << 1.662575, 0.585786437626905, -0.8284271247461900,
              -1.235281374238570)
                 .finished();

--- a/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorGPArm.cpp
+++ b/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorGPArm.cpp
@@ -95,8 +95,8 @@ TEST_UNSAFE(ObstaclePlanarSDFFactorGPArm, error) {
   q2 = Vector2(0, 0);
   qdot1 = Vector2(0, 0);
   qdot2 = Vector2(0, 0);
-  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, H1_act, H2_act, H3_act,
-                                 H4_act);
+  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, &H1_act, &H2_act,
+                                 &H3_act, &H4_act);
   sdf_exp = (Vector(4) << 1.662575, 0.60355, 0, 0).finished();
   err_exp = convertSDFtoErr(sdf_exp, obs_eps + r);
   H1_exp = numericalDerivative11(
@@ -126,8 +126,8 @@ TEST_UNSAFE(ObstaclePlanarSDFFactorGPArm, error) {
   q2 = Vector2(M_PI, 0);
   qdot1 = Vector2(M_PI * 10, 0);
   qdot2 = Vector2(M_PI * 10, 0);
-  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, H1_act, H2_act, H3_act,
-                                 H4_act);
+  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, &H1_act, &H2_act,
+                                 &H3_act, &H4_act);
   sdf_exp = (Vector(4) << 1.662575, 0.585786437626905, -0.8284271247461900,
              -1.235281374238570)
                 .finished();

--- a/gpmp2/obstacle/tests/testObstacleSDFFactorArm.cpp
+++ b/gpmp2/obstacle/tests/testObstacleSDFFactorArm.cpp
@@ -97,7 +97,7 @@ TEST(ObstacleSDFFactorArm, error) {
 
   // origin zero case
   q = Vector2(0, 0);
-  err_act = factor.evaluateError(q, H1_act);
+  err_act = factor.evaluateError(q, &H1_act);
   sdf_exp = (Vector(4) << 0.1810125, 0.099675, 0.06035, 0.06035).finished();
   err_exp = convertSDFtoErr(sdf_exp, obs_eps + r);
   H1_exp =
@@ -109,7 +109,7 @@ TEST(ObstacleSDFFactorArm, error) {
 
   // 45 deg case
   q = Vector2(M_PI / 4.0, 0);
-  err_act = factor.evaluateError(q, H1_act);
+  err_act = factor.evaluateError(q, &H1_act);
   sdf_exp = (Vector(4) << 0.1810125, 0.095702211510784, 0.01035442302156, 0)
                 .finished();
   err_exp = convertSDFtoErr(sdf_exp, obs_eps + r);

--- a/gpmp2/obstacle/tests/testObstacleSDFFactorGPArm.cpp
+++ b/gpmp2/obstacle/tests/testObstacleSDFFactorGPArm.cpp
@@ -104,8 +104,8 @@ TEST(ObstacleSDFFactorGPArm, error) {
   q2 = Vector2(0, 0);
   qdot1 = Vector2(0, 0);
   qdot2 = Vector2(0, 0);
-  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, H1_act, H2_act, H3_act,
-                                 H4_act);
+  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, &H1_act, &H2_act,
+                                 &H3_act, &H4_act);
   sdf_exp = (Vector(4) << 0.1810125, 0.099675, 0.06035, 0.06035).finished();
   err_exp = convertSDFtoErr(sdf_exp, obs_eps + r);
   H1_exp = numericalDerivative11(
@@ -135,8 +135,8 @@ TEST(ObstacleSDFFactorGPArm, error) {
   q2 = Vector2(M_PI, 0);
   qdot1 = Vector2(M_PI * 10, 0);
   qdot2 = Vector2(M_PI * 10, 0);
-  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, H1_act, H2_act, H3_act,
-                                 H4_act);
+  err_act = factor.evaluateError(q1, qdot1, q2, qdot2, &H1_act, &H2_act,
+                                 &H3_act, &H4_act);
   sdf_exp = (Vector(4) << 0.1810125, 0.095702211510784, 0.01035442302156, 0)
                 .finished();
   err_exp = convertSDFtoErr(sdf_exp, obs_eps + r);

--- a/gpmp2/obstacle/tests/testPlanarSDF.cpp
+++ b/gpmp2/obstacle/tests/testPlanarSDF.cpp
@@ -48,8 +48,8 @@ TEST(PlanarSDFutils, test1) {
 
   idx = field.convertPoint2toCell(
       Point2(0.18, -0.17));  // tri-linear interpolation
-  EXPECT_DOUBLES_EQUAL(0.3, std::get<0>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(3.8, std::get<1>(), 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.3, std::get<0>(idx), 1e-9);
+  EXPECT_DOUBLES_EQUAL(3.8, std::get<1>(idx), 1e-9);
   EXPECT_DOUBLES_EQUAL(1.567372, field.signed_distance(idx), 1e-9)
 
   idx = std::make_tuple(1.0, 2.0);

--- a/gpmp2/obstacle/tests/testPlanarSDF.cpp
+++ b/gpmp2/obstacle/tests/testPlanarSDF.cpp
@@ -42,17 +42,17 @@ TEST(PlanarSDFutils, test1) {
   // access
   PlanarSDF::float_index idx;
   idx = field.convertPoint2toCell(Point2(0, 0));
-  EXPECT_DOUBLES_EQUAL(2, idx.get<0>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(2, idx.get<1>(), 1e-9);
+  EXPECT_DOUBLES_EQUAL(2, std::get<0>(idx), 1e-9);
+  EXPECT_DOUBLES_EQUAL(2, std::get<1>(idx), 1e-9);
   EXPECT_DOUBLES_EQUAL(1, field.signed_distance(idx), 1e-9)
 
   idx = field.convertPoint2toCell(
       Point2(0.18, -0.17));  // tri-linear interpolation
-  EXPECT_DOUBLES_EQUAL(0.3, idx.get<0>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(3.8, idx.get<1>(), 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.3, std::get<0>(), 1e-9);
+  EXPECT_DOUBLES_EQUAL(3.8, std::get<1>(), 1e-9);
   EXPECT_DOUBLES_EQUAL(1.567372, field.signed_distance(idx), 1e-9)
 
-  idx = boost::make_tuple(1.0, 2.0);
+  idx = std::make_tuple(1.0, 2.0);
   EXPECT(assert_equal(Point2(0.0, -0.1), field.convertCelltoPoint2(idx)));
 
   // gradient

--- a/gpmp2/obstacle/tests/testSelfCollision.cpp
+++ b/gpmp2/obstacle/tests/testSelfCollision.cpp
@@ -38,7 +38,7 @@ TEST(SelfCollisionArm, error) {
 
   Vector3 q;
   q = Vector3(0.0, M_PI / 2.0, 0.0);
-  actual = factor.evaluateError(q, H_act);
+  actual = factor.evaluateError(q, &H_act);
   expect = (Vector(2) << 1.4928932188134527, 4.2).finished();
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector3&)>(std::bind(

--- a/gpmp2/obstacle/tests/testSelfCollision.cpp
+++ b/gpmp2/obstacle/tests/testSelfCollision.cpp
@@ -43,7 +43,7 @@ TEST(SelfCollisionArm, error) {
   H_exp =
       numericalDerivative11(std::function<Vector2(const Vector3&)>(std::bind(
                                 &SelfCollisionArm::evaluateError, factor,
-                                std::placeholders::_1, boost::none)),
+                                std::placeholders::_1, nullptr)),
                             q, 1e-6);
   EXPECT(assert_equal(expect, actual, 1e-6));
   EXPECT(assert_equal(H_exp, H_act, 1e-6));

--- a/gpmp2/obstacle/tests/testSignedDistanceField.cpp
+++ b/gpmp2/obstacle/tests/testSignedDistanceField.cpp
@@ -54,17 +54,17 @@ TEST(SDFutils, test) {
   // access
   SignedDistanceField::float_index idx;
   idx = field.convertPoint3toCell(Point3(0, 0, 0));
-  EXPECT_DOUBLES_EQUAL(2, idx.get<0>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(2, idx.get<1>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(1, idx.get<2>(), 1e-9);
+  EXPECT_DOUBLES_EQUAL(2, std::get<0>(idx), 1e-9);
+  EXPECT_DOUBLES_EQUAL(2, std::get<1>(idx), 1e-9);
+  EXPECT_DOUBLES_EQUAL(1, std::get<2>(idx), 1e-9);
   EXPECT_DOUBLES_EQUAL(0, field.signed_distance(idx), 1e-9)
   idx = field.convertPoint3toCell(
       Point3(0.18, -0.18, 0.07));  // tri-linear interpolation
-  EXPECT_DOUBLES_EQUAL(0.2, idx.get<0>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(3.8, idx.get<1>(), 1e-9);
-  EXPECT_DOUBLES_EQUAL(1.7, idx.get<2>(), 1e-9);
+  EXPECT_DOUBLES_EQUAL(0.2, std::get<0>(idx), 1e-9);
+  EXPECT_DOUBLES_EQUAL(3.8, std::get<1>(idx), 1e-9);
+  EXPECT_DOUBLES_EQUAL(1.7, std::get<2>(idx), 1e-9);
   EXPECT_DOUBLES_EQUAL(1.488288, field.signed_distance(idx), 1e-9)
-  idx = boost::make_tuple(1.0, 2.0, 3.0);
+  idx = std::make_tuple(1.0, 2.0, 3.0);
   EXPECT(assert_equal(Point3(0.0, -0.1, 0.2), field.convertCelltoPoint3(idx)));
 
   // gradient

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -2,31 +2,32 @@
 find_package(gtwrap)
 
 set(WRAP_PYTHON_VERSION
-    "Default"
-    CACHE STRING "The Python version to use for wrapping")
+  "Default"
+  CACHE STRING "The Python version to use for wrapping")
 
 gtwrap_get_python_version(${WRAP_PYTHON_VERSION})
 
-#############################################################
-##### Necessary variables to set for Matlab wrapper to work
+# ############################################################
+# #### Necessary variables to set for Matlab wrapper to work
 # Set up cache options
 option(WRAP_MEX_BUILD_STATIC_MODULE
-       "Build MATLAB wrapper statically (increases build time)" OFF)
+  "Build MATLAB wrapper statically (increases build time)" OFF)
 set(WRAP_BUILD_MEX_BINARY_FLAGS
-    ""
-    CACHE STRING "Extra flags for running Matlab MEX compilation")
+  ""
+  CACHE STRING "Extra flags for running Matlab MEX compilation")
 set(WRAP_TOOLBOX_INSTALL_PATH
-    "${CMAKE_INSTALL_PREFIX}/gpmp2_toolbox"
-    CACHE
-      PATH
-      "Matlab toolbox destination, blank defaults to CMAKE_INSTALL_PREFIX/gpmp2_toolbox"
+  "${CMAKE_INSTALL_PREFIX}/gpmp2_toolbox"
+  CACHE
+  PATH
+  "Matlab toolbox destination, blank defaults to CMAKE_INSTALL_PREFIX/gpmp2_toolbox"
 )
 
 option(
   WRAP_BUILD_TYPE_POSTFIXES
   "Enable/Disable appending the build type to the name of compiled libraries"
   ON)
-#############################################################
+
+# ############################################################
 
 # Copy matlab.h to the correct folder.
 configure_file(${PROJECT_SOURCE_DIR}/matlab/matlab.h
@@ -49,7 +50,7 @@ install(
 # Build MATLAB wrapper
 # (CMake tracks the dependecy to link with GTSAM through our project's static library)
 set(interface_files "${PROJECT_SOURCE_DIR}/gpmp2.i")
-matlab_wrap("${interface_files}" "${PROJECT_NAME}" "" "" "" "")
+matlab_wrap("${interface_files}" "${PROJECT_NAME}" "" "" "" "" "${GPMP2_ENABLE_BOOST_SERIALIZATION}")
 
 # Add the Matlab scripts that are a part of the toolbox
 install_matlab_scripts("${PROJECT_SOURCE_DIR}/matlab/" "*.m;*.fig")

--- a/matlab/matlab.h
+++ b/matlab/matlab.h
@@ -37,10 +37,6 @@ extern "C" {
 #include <mex.h>
 }
 
-#include <boost/cstdint.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
-
 #include <list>
 #include <set>
 #include <sstream>
@@ -49,7 +45,6 @@ extern "C" {
 #include <typeinfo>
 
 using namespace std;
-using namespace boost; // not usual, but for conciseness of generated code
 
 // start GTSAM Specifics /////////////////////////////////////////////////
 // to enable Matrix and Vector constructor for SharedGaussian:
@@ -66,15 +61,15 @@ using namespace boost; // not usual, but for conciseness of generated code
 // "Unique" key to signal calling the matlab object constructor with a raw pointer
 // to a shared pointer of the same C++ object type as the MATLAB type.
 // Also present in utilities.h
-static const boost::uint64_t ptr_constructor_key =
-  (boost::uint64_t('G') << 56) |
-  (boost::uint64_t('T') << 48) |
-  (boost::uint64_t('S') << 40) |
-  (boost::uint64_t('A') << 32) |
-  (boost::uint64_t('M') << 24) |
-  (boost::uint64_t('p') << 16) |
-  (boost::uint64_t('t') << 8) |
-  (boost::uint64_t('r'));
+static const std::uint64_t ptr_constructor_key =
+  (std::uint64_t('G') << 56) |
+  (std::uint64_t('T') << 48) |
+  (std::uint64_t('S') << 40) |
+  (std::uint64_t('A') << 32) |
+  (std::uint64_t('M') << 24) |
+  (std::uint64_t('p') << 16) |
+  (std::uint64_t('t') << 8) |
+  (std::uint64_t('r'));
 
 //*****************************************************************************
 // Utilities
@@ -262,9 +257,9 @@ template <typename T>
 T myGetScalar(const mxArray* array) {
   switch (mxGetClassID(array)) {
     case mxINT64_CLASS:
-      return (T) *(boost::int64_t*) mxGetData(array);
+      return (T) *(std::int64_t*) mxGetData(array);
     case mxUINT64_CLASS:
-      return (T) *(boost::uint64_t*) mxGetData(array);
+      return (T) *(std::uint64_t*) mxGetData(array);
     default:
       // hope for the best!
       return (T) mxGetScalar(array);
@@ -402,7 +397,7 @@ mxArray* create_object(const std::string& classname, void *pointer, bool isVirtu
   int nargin = 2;
   // First input argument is pointer constructor key
   input[0] = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
-  *reinterpret_cast<boost::uint64_t*>(mxGetData(input[0])) = ptr_constructor_key;
+  *reinterpret_cast<std::uint64_t*>(mxGetData(input[0])) = ptr_constructor_key;
   // Second input argument is the pointer
   input[1] = mxCreateNumericMatrix(1, 1, mxUINT32OR64_CLASS, mxREAL);
   *reinterpret_cast<void**>(mxGetData(input[1])) = pointer;
@@ -453,28 +448,28 @@ mxArray* create_object(const std::string& classname, void *pointer, bool isVirtu
  class to matlab.
 */
 template <typename Class>
-mxArray* wrap_shared_ptr(boost::shared_ptr< Class > shared_ptr, const std::string& matlabName, bool isVirtual) {
+mxArray* wrap_shared_ptr(std::shared_ptr< Class > shared_ptr, const std::string& matlabName, bool isVirtual) {
   // Create actual class object from out pointer
   mxArray* result;
   if(isVirtual) {
-    boost::shared_ptr<void> void_ptr(shared_ptr);
+    std::shared_ptr<void> void_ptr(shared_ptr);
     result = create_object(matlabName, &void_ptr, isVirtual, typeid(*shared_ptr).name());
   } else {
-    boost::shared_ptr<Class> *heapPtr = new boost::shared_ptr<Class>(shared_ptr);
+    std::shared_ptr<Class> *heapPtr = new std::shared_ptr<Class>(shared_ptr);
     result = create_object(matlabName, heapPtr, isVirtual, "");
   }
   return result;
 }
 
 template <typename Class>
-boost::shared_ptr<Class> unwrap_shared_ptr(const mxArray* obj, const string& propertyName) {
+std::shared_ptr<Class> unwrap_shared_ptr(const mxArray* obj, const string& propertyName) {
 
   mxArray* mxh = mxGetProperty(obj,0, propertyName.c_str());
   if (mxGetClassID(mxh) != mxUINT32OR64_CLASS || mxIsComplex(mxh)
     || mxGetM(mxh) != 1 || mxGetN(mxh) != 1) error(
     "Parameter is not an Shared type.");
 
-  boost::shared_ptr<Class>* spp = *reinterpret_cast<boost::shared_ptr<Class>**> (mxGetData(mxh));
+  std::shared_ptr<Class>* spp = *reinterpret_cast<std::shared_ptr<Class>**> (mxGetData(mxh));
   return *spp;
 }
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,7 +42,7 @@ pybind_wrap(
   ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.tpl
   ${PROJECT_NAME} # libraries to link against
   "${PROJECT_NAME}" # dependencies to build first
-  ON # use boost
+  ON # use boost serialization
 )
 
 set_target_properties(

--- a/python/templates/gpmp2.tpl
+++ b/python/templates/gpmp2.tpl
@@ -1,7 +1,5 @@
 // Minimal template file for wrapping C++ code.
 
-{include_boost}
-
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
@@ -9,8 +7,6 @@
 #include <pybind11/operators.h>
 #include <pybind11/functional.h>
 #include <pybind11/iostream.h>
-
-#include <boost/optional.hpp>
 
 #include "gtsam/config.h"
 #include "gtsam/base/serialization.h"
@@ -20,8 +16,6 @@
 #include <boost/serialization/export.hpp>
 
 {boost_class_export}
-
-{holder_type}
 
 // Preamble for STL classes
 #include "python/gpmp2/preamble/{module_name}.h"


### PR DESCRIPTION
This PR upgrades GPMP2 to follow the new paradigm of GTSAM that foregoes Boost.
I have updated the codebase accordingly.

Here are the task items that need to be satisfied to land this PR:
- [x] C++ tests pass.
- [x] CI passes.
- [x] Python wrapper compiles.
- [x] Python examples run.
- [x] Matlab wrapper compiles.
- [x] Matlab examples run.
- [x] @mattking-smith's work continues to operate as before.