### PR TITLE
Attempt To Fix Compilation Issue with GTSAM Tag `4.3a0 `

### DIFF
--- a/gpmp2/geometry/DynamicLieTraits.h
+++ b/gpmp2/geometry/DynamicLieTraits.h
@@ -74,6 +74,11 @@ struct DynamicLieGroupTraits {
                        ChartJacobian H = {}) {
     return m.inverse(H);
   }
+
+  static Eigen::MatrixXd AdjointMap(const Class& m) {
+    return Class::AdjointMap(m);
+  }
+
   /// @}
 };
 

--- a/gpmp2/geometry/DynamicVector.h
+++ b/gpmp2/geometry/DynamicVector.h
@@ -24,14 +24,14 @@ namespace gpmp2 {
  */
 class GPMP2_EXPORT DynamicVector {
  private:
-  size_t dim_;
-  Eigen::VectorXd vector_;
+  size_t dim_{0};
+  Eigen::VectorXd vector_{};
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /// Default constructor
-  DynamicVector() {}
+  DynamicVector() : dim_(0), vector_() {}
 
   // eigen constructor
   // non-explicit conversion enabled
@@ -89,6 +89,7 @@ class GPMP2_EXPORT DynamicVector {
 
   // equals
   bool equals(const DynamicVector& m2, double tol) const {
+    if(dim_ != m2.dim_) return false;
     return gtsam::equal_with_abs_tol(this->vector_, m2.vector_, tol);
   }
 

--- a/gpmp2/geometry/ProductDynamicLieGroup.h
+++ b/gpmp2/geometry/ProductDynamicLieGroup.h
@@ -20,8 +20,8 @@ namespace gpmp2 {
 template <typename G, typename H>
 class ProductDynamicLieGroup : public std::pair<G, H> {
  private:
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<G>));
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<H>));
+  static_assert(gtsam::IsLieGroup<G>::value, "G must satisfy the LieGroup concept");
+  static_assert(gtsam::IsLieGroup<H>::value, "H must satisfy the LieGroup concept");
   typedef std::pair<G, H> Base;
 
  protected:
@@ -239,6 +239,19 @@ class ProductDynamicLieGroup : public std::pair<G, H> {
           gtsam::traits<H>::Logmap(p.second);
       return v;
     }
+  }
+
+  static Eigen::MatrixXd AdjointMap(const ProductDynamicLieGroup& m) {
+    const size_t d1 = m.dim1();
+    const size_t d2 = m.dim2();
+    const size_t d  = d1 + d2;
+
+    Eigen::MatrixXd Adj = Eigen::MatrixXd::Zero(d, d);
+
+    Adj.topLeftCorner(d1, d1) = gtsam::traits<G>::AdjointMap(m.first);
+    Adj.bottomRightCorner(d2, d2) = gtsam::traits<H>::AdjointMap(m.second);
+
+    return Adj;
   }
 
   ProductDynamicLieGroup expmap(const TangentVector& v) const {

--- a/gpmp2/geometry/tests/testDynamicVector.cpp
+++ b/gpmp2/geometry/tests/testDynamicVector.cpp
@@ -25,10 +25,11 @@ GTSAM_CONCEPT_LIE_INST(DynamicVector)
 
 /* ************************************************************************** */
 TEST(DynamicVector, Concept) {
-  GTSAM_CONCEPT_ASSERT((IsGroup<DynamicVector>));
-  GTSAM_CONCEPT_ASSERT((IsManifold<DynamicVector>));
-  GTSAM_CONCEPT_ASSERT((IsLieGroup<DynamicVector>));
-  GTSAM_CONCEPT_ASSERT((IsVectorSpace<DynamicVector>));
+  static_assert(IsManifold<DynamicVector>::value,    "DynamicVector must satisfy the Manifold concept");
+  static_assert(IsVectorSpace<DynamicVector>::value, "DynamicVector must satisfy the VectorSpace concept");
+  static_assert(IsLieGroup<DynamicVector>::value,    "DynamicVector must satisfy the LieGroup concept");
+  // TODO : IsGroup<DynamicVector>::value does not exist in GTSAM
+  // static_assert(IsGroup<DynamicVector>::value, "DynamicVector must satisfy the Group concept");
 }
 
 /* ************************************************************************** */

--- a/gpmp2/geometry/tests/testPose2Vector.cpp
+++ b/gpmp2/geometry/tests/testPose2Vector.cpp
@@ -22,9 +22,10 @@ using namespace gpmp2;
 
 /* ************************************************************************** */
 TEST(Pose2Vector, Lie) {
-  GTSAM_CONCEPT_ASSERT((IsGroup<Pose2Vector>));
-  GTSAM_CONCEPT_ASSERT((IsManifold<Pose2Vector>));
-  GTSAM_CONCEPT_ASSERT((IsLieGroup<Pose2Vector>));
+    // TODO : IsGroup<DynamicVector>::value does not exist in GTSAM
+  // static_assert(IsGroup<DynamicVector>::value, "DynamicVector must satisfy the Group concept");
+  static_assert(IsManifold<Pose2Vector>::value, "Pose2Vector must satisfy the Manifold concept");
+  static_assert(IsLieGroup<Pose2Vector>::value, "DynamicVector must satisfy the LieGroup concept");
 }
 
 /* ************************************************************************** */

--- a/gpmp2/geometry/tests/testProductDynamicLieGroup.cpp
+++ b/gpmp2/geometry/tests/testProductDynamicLieGroup.cpp
@@ -47,9 +47,10 @@ struct traits<Product> : internal::DynamicLieGroupTraits<Product> {
 
 //******************************************************************************
 TEST(ProductDynamicLieGroup, ProductLieGroup) {
-  GTSAM_CONCEPT_ASSERT((IsGroup<Product>));
-  GTSAM_CONCEPT_ASSERT((IsManifold<Product>));
-  GTSAM_CONCEPT_ASSERT((IsLieGroup<Product>));
+  // TODO : IsGroup<DynamicVector>::value does not exist in GTSAM
+  // static_assert(IsGroup<DynamicVector>::value, "DynamicVector must satisfy the Group concept");
+  static_assert(IsManifold<Product>::value, "Product must satisfy the Manifold concept");
+  static_assert(IsLieGroup<Product>::value, "Product must satisfy the IsLieGroup concept");
   Product pair1(Point2(0, 0), Pose2());
   Vector5 d;
   d << 1, 2, 0.1, 0.2, 0.3;

--- a/gpmp2/gp/GaussianProcessInterpolatorLie.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLie.h
@@ -26,7 +26,7 @@ namespace gpmp2 {
 template <typename T>
 class GaussianProcessInterpolatorLie {
  private:
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  static_assert(gtsam::IsLieGroup<T>::value, "T must satisfy the LieGroup concept");
   typedef GaussianProcessInterpolatorLie<T> This;
 
   size_t dof_;

--- a/gpmp2/gp/GaussianProcessPriorLie.h
+++ b/gpmp2/gp/GaussianProcessPriorLie.h
@@ -24,7 +24,7 @@ template <typename T>
 class GaussianProcessPriorLie
     : public gtsam::NoiseModelFactorN<T, gtsam::Vector, T, gtsam::Vector> {
  private:
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  static_assert(gtsam::IsLieGroup<T>::value, "T must satisfy the LieGroup concept");
   typedef GaussianProcessPriorLie<T> This;
   typedef gtsam::NoiseModelFactorN<T, gtsam::Vector, T, gtsam::Vector> Base;
 


### PR DESCRIPTION
# Purpose
This PR fixes compilation issues with the current development build of GTSAM (I believe `4.3a0` correct me if I am wrong @dellaert) and attempts to close issue #28. 

# Steps To Verify
- [x] build `GTSAM` `develop`
- [x] build `GPMP2`
- [x] build all C++ unit tests
- [ ] pass all C++ unit tests
- [ ] pass `Python` unit tests
- [ ]  pass `Matlab` unit tests (I don't own `Matlab` @dellaert can you have someone verify?)

# Build Configuration
- `GTSAM` `Debug` with memory leak / `GDB` memory sanitizer
- `GPMP2` `Debug`

# Current Problem
The build instructions now result in the following:
```shell
make -j4 check
.
.
.
76% tests passed, 9 tests failed out of 37

Total Test time (real) =   3.38 sec

The following tests FAILED:
          4 - testGaussianProcessInterpolatorLinear (Failed)
          5 - testGaussianProcessInterpolatorPose2 (Failed)
          6 - testGaussianProcessInterpolatorPose2Vector (Failed)
          7 - testGaussianProcessInterpolatorPose3 (Failed)
         11 - testGaussianProcessPriorPose3 (Subprocess aborted)
         20 - testMobileBaseUtils (Subprocess aborted)
         22 - testPose2Mobile2Arms (Subprocess aborted)
         25 - testPose2MobileVetLin2Arms (Subprocess aborted)
         26 - testPose2MobileVetLinArm (Subprocess aborted)
```

Specifically, most test fail due to segfaults like `testGaussianProcessInterpolatorLinear`:
```
4/37 Test  #4: testGaussianProcessInterpolatorLinear ........***Failed    0.29 sec
AddressSanitizer:DEADLYSIGNAL
=================================================================
==140968==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55fd43da375f bp 0x7fff997a26b0 sp 0x7fff997a2698 T0)
==140968==The signal is caused by a READ memory access.
==140968==Hint: address points to the zero page.
    #0 0x55fd43da375e in _mm256_load_pd /usr/lib/gcc/x86_64-linux-gnu/9/include/avxintrin.h:862
    #1 0x55fd43da375e in double __vector(4) Eigen::internal::pload<double __vector(4)>(Eigen::internal::unpacket_traits<double __vector(4)>::type const*) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/arch/AVX/PacketMath.h:578
    #2 0x55fd43db7509 in double __vector(4) Eigen::internal::ploadt<double __vector(4), 32>(Eigen::internal::unpacket_traits<double __vector(4)>::type const*) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/GenericPacketMath.h:967
    #3 0x55fd43db7509 in double __vector(4) Eigen::internal::evaluator<Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > >::packet<32, double __vector(4)>(long) const /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/CoreEvaluators.h:245
    #4 0x55fd43db75e7 in void Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::internal::evaluator<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::internal::assign_op<double, double>, 0>::assignPacket<32, 32, double __vector(4)>(long) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:681
    #5 0x55fd43dbdfea in Eigen::internal::dense_assignment_loop<Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::internal::evaluator<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::internal::assign_op<double, double>, 0>, 3, 0>::run(Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::internal::evaluator<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::internal::assign_op<double, double>, 0>&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:437
    #6 0x55fd43dbe109 in void Eigen::internal::call_dense_assignment_loop<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::internal::assign_op<double, double> >(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, Eigen::internal::assign_op<double, double> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:785
    #7 0x55fd43dbe1b8 in Eigen::internal::Assignment<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::internal::assign_op<double, double>, Eigen::internal::Dense2Dense, void>::run(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, Eigen::internal::assign_op<double, double> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:954
    #8 0x55fd43dbe1c7 in void Eigen::internal::call_assignment_no_alias<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::internal::assign_op<double, double> >(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, Eigen::internal::assign_op<double, double> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:890
    #9 0x55fd43dd062e in void Eigen::internal::call_assignment<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::internal::assign_op<double, double> >(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, Eigen::internal::assign_op<double, double> const&, Eigen::internal::enable_if<!Eigen::internal::evaluator_assume_aliasing<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::internal::evaluator_traits<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::Shape>::value, void*>::type) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:858
    #10 0x55fd43dd06c1 in void Eigen::internal::call_assignment<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Matrix<double, -1, -1, 0, -1, -1> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:836
    #11 0x55fd43dd0759 in Eigen::Matrix<double, -1, -1, 0, -1, -1>& Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::_set<Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::DenseBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/PlainObjectBase.h:779
    #12 0x55fd43dd0774 in Eigen::Matrix<double, -1, -1, 0, -1, -1>::operator=(Eigen::Matrix<double, -1, -1, 0, -1, -1> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/Matrix.h:208
    #13 0x55fd43e23982 in Eigen::PartialPivLU<Eigen::Matrix<double, -1, -1, 0, -1, -1> >& Eigen::PartialPivLU<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::compute<Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::EigenBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/LU/PartialPivLU.h:132
    #14 0x55fd43e23b73 in Eigen::PartialPivLU<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::PartialPivLU<Eigen::Matrix<double, -1, -1, 0, -1, -1> >(Eigen::EigenBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> > const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/LU/PartialPivLU.h:315
    #15 0x7fdd0a743736 in Eigen::MatrixBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::partialPivLu() const /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/LU/PartialPivLU.h:604
    #16 0x7fdd0a743736 in Eigen::internal::compute_inverse<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, -1, 0, -1, -1>, -1>::run(Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, Eigen::Matrix<double, -1, -1, 0, -1, -1>&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/LU/InverseImpl.h:28
    #17 0x7fdd0a743736 in Eigen::internal::Assignment<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> >, Eigen::internal::assign_op<double, double>, Eigen::internal::Dense2Dense, void>::run(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > const&, Eigen::internal::assign_op<double, double> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/LU/InverseImpl.h:322
    #18 0x7fdd0a743736 in void Eigen::internal::call_assignment_no_alias<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> >, Eigen::internal::assign_op<double, double> >(Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > const&, Eigen::internal::assign_op<double, double> const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/AssignEvaluator.h:890
    #19 0x7fdd0a743736 in Eigen::Matrix<double, -1, -1, 0, -1, -1>& Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::_set_noalias<Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > >(Eigen::DenseBase<Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > > const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/PlainObjectBase.h:797
    #20 0x7fdd0a743736 in Eigen::PlainObjectBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::PlainObjectBase<Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > >(Eigen::DenseBase<Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > > const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/PlainObjectBase.h:594
    #21 0x7fdd0a743736 in Eigen::Matrix<double, -1, -1, 0, -1, -1>::Matrix<Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > >(Eigen::EigenBase<Eigen::Inverse<Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> >, Eigen::Matrix<double, -1, -1, 0, -1, -1>, 0> > > const&) /usr/local/include/gtsam/3rdparty/Eigen/Eigen/src/Core/Matrix.h:423
    #22 0x7fdd0a743736 in gpmp2::getQc(std::shared_ptr<gtsam::noiseModel::Base>) /home/matt/Repos/SCATE_Satellite_Inspection/external/gpmp2/gpmp2/gp/GPutils.cpp:18
    #23 0x55fd43e2823c in gpmp2::GaussianProcessInterpolatorLinear::GaussianProcessInterpolatorLinear(std::shared_ptr<gtsam::noiseModel::Base>, double, double) /home/matt/Repos/SCATE_Satellite_Inspection/external/gpmp2/gpmp2/gp/GaussianProcessInterpolatorLinear.h:52
    #24 0x55fd43d92ccb in GaussianProcessInterpolatorLinearequalsTest::run(TestResult&) /home/matt/Repos/SCATE_Satellite_Inspection/external/gpmp2/gpmp2/gp/tests/testGaussianProcessInterpolatorLinear.cpp:28
    #25 0x55fd43e2a9e9 in TestRegistry::run(TestResult&) /home/matt/Repos/SCATE_Satellite_Inspection/external/gtsam/CppUnitLite/TestRegistry.cpp:62
    #26 0x55fd43e2a63c in TestRegistry::runAllTests(TestResult&) /home/matt/Repos/SCATE_Satellite_Inspection/external/gtsam/CppUnitLite/TestRegistry.cpp:29
    #27 0x55fd43d91d3e in main /home/matt/Repos/SCATE_Satellite_Inspection/external/gpmp2/gpmp2/gp/tests/testGaussianProcessInterpolatorLinear.cpp:197
    #28 0x7fdd046cc082 in __libc_start_main ../csu/libc-start.c:308
    #29 0x55fd43d91bed in _start (/home/matt/Repos/SCATE_Satellite_Inspection/external/gpmp2/build/gpmp2/gp/testGaussianProcessInterpolatorLinear+0xf1bed)
```

Any help from current gtsam contributors (@dellaert) would be appreciated, thank you.