### PR TITLE
Fix GPMP2 Build Via GTSAM `git submodule` Import

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -1,6 +1,6 @@
 name: Linux CI
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -67,31 +67,25 @@ jobs:
           # Install CppUnitLite.
           git clone https://github.com/borglab/CppUnitLite.git
           cd CppUnitLite && mkdir build && cd $_
-          cmake .. && sudo make -j4 install
-          cd ../../
-
-      - name: Install GTSAM
-        run: |
-          git clone https://github.com/borglab/gtsam.git
-          cd gtsam && mkdir build && cd $_
-          cmake -DGTSAM_ALLOW_DEPRECATED_SINCE_V43=OFF -DGTSAM_WITH_TBB=OFF -DGTSAM_BUILD_UNSTABLE=OFF .. && sudo make -j4 install
+          cmake .. && sudo make -j$(nproc) install
           cd ../../
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive # initialize submodules (GTSAM)
 
       - name: Build Directory
-        run: mkdir build
+        run: mkdir -p build
 
-      - name: Configure
-        run: |
-          cmake -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF ..
+      - name: Configure GPMP2
+        run: cmake ..
         working-directory: ./build
 
-      - name: Build
+      - name: Build GPMP2
         run: make -j$(nproc)
         working-directory: ./build
 
-      - name: Test
+      - name: Test GPMP2
         run: make -j$(nproc) check
         working-directory: ./build

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive # initialize submodules (GTSAM)
 
       - name: Build Directory
         run: mkdir ./build

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -1,6 +1,6 @@
 name: macOS CI
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -38,18 +38,14 @@ jobs:
           brew install boost
           brew tap borglab/core
 
-      - name: GTSAM
-        run: brew install --HEAD gtsam@latest
-
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build Directory
         run: mkdir ./build
 
-      - name: Configure
-        run: |
-          cmake -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF ..
+      - name: Configure GPMP2
+        run: cmake ..
         working-directory: ./build
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build*
 *.pyc
 *.asv
 **/.DS_Store
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build*
+deps*
+install*
 *.pyc
 *.asv
 **/.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/gtsam"]
+	path = extern/gtsam
+	url = https://github.com/borglab/gtsam.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 enable_testing()
 project(gpmp2
         LANGUAGES CXX C
@@ -13,11 +13,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #TODO(Varun) Verify C++17 is enabled on Windows as well
 # Look at GtsamBuildTypes L153
-
-# Mac ONLY. Define Relative Path on Mac OS
-if(NOT DEFINED CMAKE_MACOSX_RPATH)
-  set(CMAKE_MACOSX_RPATH 0)
-endif()
 
 # version indicator
 set(GPMP2_VERSION_MAJOR 1)
@@ -39,7 +34,7 @@ if(GPMP2_ENABLE_BOOST_SERIALIZATION)
 endif()
 
 if(GPMP2_BUILD_STATIC_LIBRARY AND GPMP2_BUILD_MATLAB_TOOLBOX)
-  message(FATAL_ERROR "Matlab toolbox needs static lib to be built")
+  message(FATAL_ERROR "Matlab toolbox needs shared lib to be built")
 endif()
 
 
@@ -49,11 +44,11 @@ include_directories(${GTSAM_INCLUDE_DIR})
 set(GTSAM_LIBRARIES gtsam)   # TODO: automatic search libs
 
 find_package(GTSAMCMakeTools)
-include(GtsamMakeConfigFile)
 include(GtsamBuildTypes)
 include(GtsamTesting)
+include(GtsamPrinting)
 
-# for unittest scripts
+# for unit tests and scripts
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${GTSAM_DIR}/../GTSAMCMakeTools")
 
 # Boost - same requirement as gtsam
@@ -65,8 +60,7 @@ include_directories(${Boost_INCLUDE_DIR})
 configure_file("gpmp2/config.h.in" "gpmp2/config.h")
 list(APPEND gpmp2_srcs "${PROJECT_BINARY_DIR}/gpmp2/config.h")
 include_directories(BEFORE ${PROJECT_BINARY_DIR}) # So we can include generated config header files
-install(FILES "${PROJECT_BINARY_DIR}/gpmp2/config.h" DESTINATION include/gpmp2)
-
+install(FILES "${PROJECT_BINARY_DIR}/gpmp2/config.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gpmp2)
 
 # include current source folder, at the very beginning
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -87,5 +81,5 @@ if(GPMP2_BUILD_PYTHON_TOOLBOX)
 endif()
 
 # Install config and export files
-GtsamMakeConfigFile(gpmp2)
-export(TARGETS ${GPMP2_EXPORTED_TARGETS} FILE gpmp2-exports.cmake)
+# GtsamMakeConfigFile(gpmp2)
+# export(TARGETS ${GPMP2_EXPORTED_TARGETS} FILE gpmp2-exports.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(gpmp2
         VERSION 1.0.0)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 
+set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/install" CACHE PATH "Local install prefix" FORCE)
+
 add_compile_options(-faligned-new)
 
 # Enforce c++17 standards
@@ -37,13 +39,81 @@ if(GPMP2_BUILD_STATIC_LIBRARY AND GPMP2_BUILD_MATLAB_TOOLBOX)
   message(FATAL_ERROR "Matlab toolbox needs shared lib to be built")
 endif()
 
+# === Local GTSAM bootstrap ===
+set(GTSAM_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/gtsam")
+set(GTSAM_DEPS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/gtsam")
+set(GTSAM_BUILD_DIR "${GTSAM_DEPS_DIR}/build")
+set(GTSAM_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/gtsam")
 
-# Find GTSAM components
-find_package(GTSAM REQUIRED) # Uses installed package
+# Ensure submodule is initialized
+if(NOT EXISTS "${GTSAM_SUBMODULE_DIR}/CMakeLists.txt")
+  message(STATUS "Initializing GTSAM submodule...")
+  execute_process(
+    COMMAND git submodule update --init --recursive extern/gtsam
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE GTSAM_SUBMODULE_RESULT
+  )
+  if(NOT GTSAM_SUBMODULE_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to initialize GTSAM submodule.")
+    return()
+  endif()
+endif()
+
+# Build and install GTSAM locally if not already built
+if(NOT EXISTS "${GTSAM_INSTALL_DIR}/lib/cmake/GTSAM/GTSAMConfig.cmake")
+  message(STATUS "Building and installing GTSAM locally...")
+
+  file(MAKE_DIRECTORY ${GTSAM_BUILD_DIR})
+
+  execute_process(
+    COMMAND cmake
+      -DCMAKE_INSTALL_PREFIX=${GTSAM_INSTALL_DIR}
+      -DGTSAM_BUILD_DOCS=OFF
+      -DGTSAM_BUILD_DOC_HTML=OFF
+      -DGTSAM_BUILD_DOC_LATEX=OFF
+      -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF
+      -DGTSAM_BUILD_TESTS=OFF
+      ${GTSAM_SUBMODULE_DIR}
+    WORKING_DIRECTORY ${GTSAM_BUILD_DIR}
+    RESULT_VARIABLE GTSAM_CMAKE_RESULT
+  )
+  if(NOT GTSAM_CMAKE_RESULT EQUAL 0)
+    message(FATAL_ERROR "CMake configuration for GTSAM failed.")
+    return()
+  endif()
+
+  include(ProcessorCount)
+  ProcessorCount(NPROC)
+  execute_process(
+    COMMAND make -j${NPROC} install
+    WORKING_DIRECTORY ${GTSAM_BUILD_DIR}
+    RESULT_VARIABLE GTSAM_BUILD_RESULT
+  )
+  if(NOT GTSAM_BUILD_RESULT EQUAL 0)
+    message(FATAL_ERROR "GTSAM build or install failed.")
+  endif()
+endif()
+
+# Point GPMP2 to local GTSAM install
+set(GTSAM_DIR "${GTSAM_INSTALL_DIR}/lib/cmake/GTSAM" CACHE PATH "Local GTSAM" FORCE)
+find_package(GTSAM REQUIRED NO_DEFAULT_PATH)
+
+message(STATUS "Using local GTSAM from: ${GTSAM_DIR}")
 include_directories(${GTSAM_INCLUDE_DIR})
-set(GTSAM_LIBRARIES gtsam)   # TODO: automatic search libs
+set(GTSAM_LIBRARIES gtsam)
 
-find_package(GTSAMCMakeTools)
+# Include GTSAM CMake tools (installed or source fallback)
+set(GTSAMCMakeTools_INSTALLED_DIR "${GTSAM_INSTALL_DIR}/lib/cmake/GTSAMCMakeTools")
+set(GTSAMCMakeTools_SOURCE_DIR "${GTSAM_SUBMODULE_DIR}/cmake")
+
+if(EXISTS "${GTSAMCMakeTools_INSTALLED_DIR}/GtsamTesting.cmake")
+  list(APPEND CMAKE_MODULE_PATH "${GTSAMCMakeTools_INSTALLED_DIR}")
+elseif(EXISTS "${GTSAMCMakeTools_SOURCE_DIR}/GtsamTesting.cmake")
+  list(APPEND CMAKE_MODULE_PATH "${GTSAMCMakeTools_SOURCE_DIR}")
+else()
+  message(FATAL_ERROR "Could not locate GTSAMCMakeTools (neither installed nor source).")
+endif()
+
 include(GtsamBuildTypes)
 include(GtsamTesting)
 include(GtsamPrinting)
@@ -60,7 +130,7 @@ include_directories(${Boost_INCLUDE_DIR})
 configure_file("gpmp2/config.h.in" "gpmp2/config.h")
 list(APPEND gpmp2_srcs "${PROJECT_BINARY_DIR}/gpmp2/config.h")
 include_directories(BEFORE ${PROJECT_BINARY_DIR}) # So we can include generated config header files
-install(FILES "${PROJECT_BINARY_DIR}/gpmp2/config.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gpmp2)
+install(FILES "${PROJECT_BINARY_DIR}/gpmp2/config.h" DESTINATION ${CMAKE_INSTALL_PREFIX}/gpmp2)
 
 # include current source folder, at the very beginning
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ if(GPMP2_BUILD_PYTHON_TOOLBOX)
 endif()
 
 # Install config and export files
+include(GtsamMakeConfigFile)
 GtsamMakeConfigFile(gpmp2)
 export(TARGETS ${GPMP2_EXPORTED_TARGETS} FILE gpmp2-exports.cmake)
 

--- a/README.md
+++ b/README.md
@@ -13,30 +13,12 @@ This library is an implementation of GPMP2 (Gaussian Process Motion Planner 2) a
 
 ## Installation (C++ only)
 
-- Install GTSAM.
-  ```bash
-  git clone https://github.com/borglab/gtsam.git
-  cd gtsam
-  mkdir build && cd build
-  cmake -DGTSAM_ALLOW_DEPRECATED_SINCE_V42:=OFF .. # disable deprecated functionality for compatibility
-  make -j4 check # optional, run unit tests  
-  sudo make install
-  ```
-
-- Setup paths.
-  ```bash
-  echo 'export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}' >> ~/.bashrc
-  echo 'export LD_LIBRARY_PATH=/usr/local/share:${LD_LIBRARY_PATH}' >> ~/.bashrc
-  source ~/.bashrc
-  ```
-
 - Install gpmp2.
   ```bash
-  git clone https://github.com/borglab/gpmp2.git
-  cd gpmp2 && mkdir build && cd build
-  cmake ..
-  make -j4 check  # optional, run unit tests
-  sudo make install
+  mkdir -p build && cd build
+  cmake .. # Initialize and build compatible GTSAM git submodule locally
+  make -j$(nproc)
+  make install
   ```
 
 ## Python Package Installation
@@ -49,7 +31,7 @@ This library is an implementation of GPMP2 (Gaussian Process Motion Planner 2) a
   ```
 
 - Install the `gtwrap` project.
-  
+
   If you compile and install GTSAM with the python wrapper enabled, you will automatically have `gtwrap` and you can continue to the next step.
   Else, please clone and install the [gtwrap project](https://github.com/borglab/wrap).
 

--- a/gpmp2/geometry/DynamicLieTraits.h
+++ b/gpmp2/geometry/DynamicLieTraits.h
@@ -74,6 +74,8 @@ struct DynamicLieGroupTraits {
                        ChartJacobian H = {}) {
     return m.inverse(H);
   }
+
+  static Eigen::MatrixXd AdjointMap(const Class& m) { return m.AdjointMap(); }
   /// @}
 };
 

--- a/gpmp2/geometry/ProductDynamicLieGroup.h
+++ b/gpmp2/geometry/ProductDynamicLieGroup.h
@@ -10,6 +10,7 @@
 
 #include <gpmp2/geometry/utilsDynamic.h>
 #include <gtsam/base/Lie.h>
+#include <gtsam/base/ProductLieGroup.h>
 
 #include <utility>  // pair
 
@@ -18,11 +19,11 @@ namespace gpmp2 {
 /// Template to construct the product Lie group of two other Lie groups
 /// Assumes Lie group structure for G and H, at least one is dynamic size types
 template <typename G, typename H>
-class ProductDynamicLieGroup : public std::pair<G, H> {
+class ProductDynamicLieGroup : public gtsam::ProductLieGroup<G, H> {
  private:
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<G>));
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<H>));
-  typedef std::pair<G, H> Base;
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<G>);
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<H>);
+  typedef gtsam::ProductLieGroup<G, H> Base;
 
  protected:
   // static dimensions

--- a/gpmp2/geometry/tests/testDynamicVector.cpp
+++ b/gpmp2/geometry/tests/testDynamicVector.cpp
@@ -25,10 +25,10 @@ GTSAM_CONCEPT_LIE_INST(DynamicVector)
 
 /* ************************************************************************** */
 TEST(DynamicVector, Concept) {
-  GTSAM_CONCEPT_ASSERT((IsGroup<DynamicVector>));
-  GTSAM_CONCEPT_ASSERT((IsManifold<DynamicVector>));
-  GTSAM_CONCEPT_ASSERT((IsLieGroup<DynamicVector>));
-  GTSAM_CONCEPT_ASSERT((IsVectorSpace<DynamicVector>));
+  GTSAM_CONCEPT_ASSERT(IsGroup<DynamicVector>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<DynamicVector>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<DynamicVector>);
+  GTSAM_CONCEPT_ASSERT(IsVectorSpace<DynamicVector>);
 }
 
 /* ************************************************************************** */

--- a/gpmp2/geometry/tests/testPose2Vector.cpp
+++ b/gpmp2/geometry/tests/testPose2Vector.cpp
@@ -22,9 +22,9 @@ using namespace gpmp2;
 
 /* ************************************************************************** */
 TEST(Pose2Vector, Lie) {
-  GTSAM_CONCEPT_ASSERT((IsGroup<Pose2Vector>));
-  GTSAM_CONCEPT_ASSERT((IsManifold<Pose2Vector>));
-  GTSAM_CONCEPT_ASSERT((IsLieGroup<Pose2Vector>));
+  GTSAM_CONCEPT_ASSERT(IsGroup<Pose2Vector>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Pose2Vector>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Pose2Vector>);
 }
 
 /* ************************************************************************** */

--- a/gpmp2/geometry/tests/testProductDynamicLieGroup.cpp
+++ b/gpmp2/geometry/tests/testProductDynamicLieGroup.cpp
@@ -47,9 +47,9 @@ struct traits<Product> : internal::DynamicLieGroupTraits<Product> {
 
 //******************************************************************************
 TEST(ProductDynamicLieGroup, ProductLieGroup) {
-  GTSAM_CONCEPT_ASSERT((IsGroup<Product>));
-  GTSAM_CONCEPT_ASSERT((IsManifold<Product>));
-  GTSAM_CONCEPT_ASSERT((IsLieGroup<Product>));
+  GTSAM_CONCEPT_ASSERT(IsGroup<Product>);
+  GTSAM_CONCEPT_ASSERT(IsManifold<Product>);
+  GTSAM_CONCEPT_ASSERT(IsLieGroup<Product>);
   Product pair1(Point2(0, 0), Pose2());
   Vector5 d;
   d << 1, 2, 0.1, 0.2, 0.3;

--- a/gpmp2/gp/GaussianProcessInterpolatorLie.h
+++ b/gpmp2/gp/GaussianProcessInterpolatorLie.h
@@ -26,7 +26,7 @@ namespace gpmp2 {
 template <typename T>
 class GaussianProcessInterpolatorLie {
  private:
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<T>);
   typedef GaussianProcessInterpolatorLie<T> This;
 
   size_t dof_;

--- a/gpmp2/gp/GaussianProcessPriorLie.h
+++ b/gpmp2/gp/GaussianProcessPriorLie.h
@@ -24,7 +24,7 @@ template <typename T>
 class GaussianProcessPriorLie
     : public gtsam::NoiseModelFactorN<T, gtsam::Vector, T, gtsam::Vector> {
  private:
-  GTSAM_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<T>);
   typedef GaussianProcessPriorLie<T> This;
   typedef gtsam::NoiseModelFactorN<T, gtsam::Vector, T, gtsam::Vector> Base;
 


### PR DESCRIPTION
# Purpose
This PR fixes compilation issues with the current building of GPMP2 but importing GTSAM as a `git submodule` and pointing it at a compatible GTSAM tag `4.3a0` (no `ROS`) and should close issue #28. 

Additionally, this makes building and installing GPMP2 streamlined and does not require `sudo` privileges. 

## Steps To Verify
- [x] build `GTSAM` `develop`
- [x] build `GPMP2`
- [x] build all C++ unit tests
- [ ] pass all C++ unit tests
- [ ] pass `Python` unit tests
- [ ]  pass `Matlab` unit tests (I don't own `Matlab`)