### PR TITLE
Feature: Compute Euclidean Distance Transforms of Binary Obstacle Maps

### DIFF
--- a/gpmp2/obstacle/DistanceTransform.cpp
+++ b/gpmp2/obstacle/DistanceTransform.cpp
@@ -53,35 +53,74 @@ Eigen::VectorXd computeEuclideanDistanceTransform(Eigen::VectorXd const & func_)
     return distanceTransform;
 }
 
-gtsam::Matrix computeEDTFromBinary(gtsam::Matrix const & binaryMap_)
+std::vector<gtsam::Matrix> computeEDTFromBinary(std::vector<gtsam::Matrix> const & binaryVolume)
 {
-    auto const rows = binaryMap_.rows();
-    auto const cols = binaryMap_.cols();
-
-    // Convert binary map to function map: 0 → free space, 1 → obstacle
-    gtsam::Matrix funcMap_(rows,cols);
-    funcMap_ = binaryMap_.unaryExpr([](double x)
+    if(binaryVolume.empty())
     {
-        return x == 1.0 ? 0.0 : std::numeric_limits<double>::max();
-    });
-
-    gtsam::Matrix edt(rows, cols);
-
-    // --- Row-wise pass ---
-    for(size_t r = 0; r < rows; ++r)
-    {
-        Eigen::VectorXd const f = funcMap_.row(r).transpose();
-        edt.row(r)  = computeEuclideanDistanceTransform(f);
+        std::cerr << "Cannot compute edt of binaryVolume which is empty!\n";
+        return {};
     }
 
-    // --- Pass in y-direction (rows) ---
-    for(size_t c = 0; c< cols; ++c)
+    size_t const Z = binaryVolume.size();
+    size_t const Y = binaryVolume[0].rows();
+    size_t const X = binaryVolume[0].cols();
+
+    // --- Step 1: build function map ---
+    std::vector<gtsam::Matrix> edt(Z, gtsam::Matrix(Y, X));
+
+    for (size_t z = 0; z < Z; ++z)
     {
-        Eigen::VectorXd const f = edt.col(c);
-        edt.col(c)  = computeEuclideanDistanceTransform(f);
+        edt[z] = binaryVolume[z].unaryExpr([](double const x_)
+        {
+            return x_ == 1.0 ? 0.0 : std::numeric_limits<double>::max();
+        });
     }
+
+    // --- Step 2: X pass (rows) ---
+    for (size_t z = 0; z < Z; ++z)
+    {
+        for (size_t y = 0; y < Y; ++y)
+        {
+            Eigen::VectorXd f = edt[z].row(y).transpose();
+            Eigen::VectorXd d = computeEuclideanDistanceTransform(f);
+            edt[z].row(y) = d.transpose();
+        }
+    }
+
+    // --- Step 3: Y pass (cols) ---
+    for (size_t z = 0; z < Z; ++z)
+    {
+        for (size_t x = 0; x < X; ++x)
+        {
+            Eigen::VectorXd f = edt[z].col(x);
+            Eigen::VectorXd d = computeEuclideanDistanceTransform(f);
+            edt[z].col(x) = d;
+        }
+    }
+
+    if(Z < 2)
+        // Only a single matrix nothing left to compute
+        return edt;
+
+    // --- Step 4: Z pass ---
+    for (size_t y = 0; y < Y; ++y)
+    {
+        for (size_t x = 0; x < X; ++x)
+        {
+            Eigen::VectorXd f(Z);
+
+            for (size_t z = 0; z < Z; ++z)
+                f[z] = edt[z](y, x);
+
+            Eigen::VectorXd d = computeEuclideanDistanceTransform(f);
+
+            for (size_t z = 0; z < Z; ++z)
+                edt[z](y, x) = d[z];
+        }
+    }
+
     return edt;
-};
+}
 
 } // namespace anonymous
 
@@ -93,12 +132,36 @@ gtsam::Matrix gpmp2::dt::roundMatrix(gtsam::Matrix const & mat_, int const decim
 
 gtsam::Matrix gpmp2::dt::computeSignedDistanceField(gtsam::Matrix const & binaryMap_, double const cellSize_)
 {
-    gtsam::Matrix const distToObject = computeEDTFromBinary(binaryMap_);
-    gtsam::Matrix const distToObjectSqrt = distToObject.array().sqrt();
+    return computeSignedDistanceField(std::vector<gtsam::Matrix>{binaryMap_}, cellSize_).at(0);
+}
 
-    gtsam::Matrix const invBinaryMap = gtsam::Matrix::Ones(binaryMap_.rows(), binaryMap_.cols()) - binaryMap_;
-    gtsam::Matrix const distToBackground = computeEDTFromBinary(invBinaryMap);
-    gtsam::Matrix const distToBackgroundSqrt = distToBackground.array().sqrt();
+std::vector<gtsam::Matrix> gpmp2::dt::computeSignedDistanceField(
+    std::vector<gtsam::Matrix> const & binaryVolume_,
+    double cellSize_)
+{
+    // distance to object (inside obstacles)
+    auto distObj = computeEDTFromBinary(binaryVolume_);
 
-    return (distToObjectSqrt - distToBackgroundSqrt) * cellSize_;
+    // build inverse
+    std::vector<gtsam::Matrix> inv(binaryVolume_.size());
+    for (size_t z = 0; z < binaryVolume_.size(); ++z)
+    {
+        inv[z] = gtsam::Matrix::Ones(binaryVolume_[z].rows(),
+                                    binaryVolume_[z].cols()) - binaryVolume_[z];
+    }
+
+    // distance to background
+    auto distBg = computeEDTFromBinary(inv);
+
+    // combine → signed distance
+    std::vector<gtsam::Matrix> sdf(binaryVolume_.size());
+
+    for (size_t z = 0; z < binaryVolume_.size(); ++z)
+    {
+        sdf[z] =
+            (distObj[z].array().sqrt() -
+             distBg[z].array().sqrt()) * cellSize_;
+    }
+
+    return sdf;
 }

--- a/gpmp2/obstacle/DistanceTransform.cpp
+++ b/gpmp2/obstacle/DistanceTransform.cpp
@@ -85,6 +85,12 @@ gtsam::Matrix computeEDTFromBinary(gtsam::Matrix const & binaryMap_)
 
 } // namespace anonymous
 
+gtsam::Matrix gpmp2::dt::roundMatrix(gtsam::Matrix const & mat_, int const decimals_)
+{
+    double scale = std::pow(10.0, decimals_);
+    return (mat_ * scale).array().round() / scale;
+}
+
 gtsam::Matrix gpmp2::dt::computeSignedDistanceField(gtsam::Matrix const & binaryMap_, double const cellSize_)
 {
     gtsam::Matrix const distToObject = computeEDTFromBinary(binaryMap_);

--- a/gpmp2/obstacle/DistanceTransform.cpp
+++ b/gpmp2/obstacle/DistanceTransform.cpp
@@ -142,9 +142,11 @@ std::vector<gtsam::Matrix> gpmp2::dt::computeSignedDistanceField(
     // distance to object (inside obstacles)
     auto distObj = computeEDTFromBinary(binaryVolume_);
 
+    size_t const volSize = binaryVolume_.size();
+
     // build inverse
-    std::vector<gtsam::Matrix> inv(binaryVolume_.size());
-    for (size_t z = 0; z < binaryVolume_.size(); ++z)
+    std::vector<gtsam::Matrix> inv(volSize);
+    for (size_t z = 0; z < volSize; ++z)
     {
         inv[z] = gtsam::Matrix::Ones(binaryVolume_[z].rows(),
                                     binaryVolume_[z].cols()) - binaryVolume_[z];
@@ -154,9 +156,9 @@ std::vector<gtsam::Matrix> gpmp2::dt::computeSignedDistanceField(
     auto distBg = computeEDTFromBinary(inv);
 
     // combine → signed distance
-    std::vector<gtsam::Matrix> sdf(binaryVolume_.size());
+    std::vector<gtsam::Matrix> sdf(volSize);
 
-    for (size_t z = 0; z < binaryVolume_.size(); ++z)
+    for (size_t z = 0; z < volSize; ++z)
     {
         sdf[z] =
             (distObj[z].array().sqrt() -

--- a/gpmp2/obstacle/DistanceTransform.cpp
+++ b/gpmp2/obstacle/DistanceTransform.cpp
@@ -1,0 +1,98 @@
+/**
+ *  @file   SignedDistanceFieldConverter.cpp
+ *  @brief  Converts binary 2D and 3D volumes to signed distance fields
+ *  @author Matthew King-Smith
+ *  @date   Nov 16, 2025
+ **/
+
+#include <gpmp2/obstacle/DistanceTransform.h>
+
+#include <cmath>
+#include <limits>
+
+namespace
+{
+
+Eigen::VectorXd computeEuclideanDistanceTransform(Eigen::VectorXd const & func_)
+{
+    size_t const dim = func_.size();
+    size_t k = 0; ///< Index of right most parabola in lower envelope
+    Eigen::VectorXi v(dim); ///< Locations of parabolas in lower envelope
+    Eigen::VectorXd z(dim + 1); ///< Locations of boundaries between parabolas
+    v[0] = 0;
+    z[0] = -std::numeric_limits<double>::infinity();
+    z[1] =  std::numeric_limits<double>::infinity();
+
+    // Compute lower envelope
+    double s; /// < Parabola intersection point
+    for(size_t q = 1; q < dim; ++q)
+    {
+
+        while(true)
+        {
+            s = ((func_[q] + static_cast<double>(q*q)) - (func_[v[k]] + static_cast<double>(v[k]*v[k]))) / (2.0 * static_cast<double>(q - v[k]));
+
+            if (s > z[k]) break;
+
+            if (k == 0) break;
+            k--;
+        }
+        ++k;
+        v[k]   = q;
+        z[k]   = s;
+        z[k+1] = std::numeric_limits<double>::infinity();
+    }
+
+    k = 0;
+    Eigen::VectorXd distanceTransform = Eigen::VectorXd::Zero(dim);
+    for(size_t q = 0; q < dim; ++q)
+    {
+        while (z[k+1] < static_cast<double>(q)) ++k;
+        distanceTransform[q] = static_cast<double>((q - v[k]) * (q - v[k])) + func_[v[k]];
+    }
+    return distanceTransform;
+}
+
+gtsam::Matrix computeEDTFromBinary(gtsam::Matrix const & binaryMap_)
+{
+    auto const rows = binaryMap_.rows();
+    auto const cols = binaryMap_.cols();
+
+    // Convert binary map to function map: 0 → free space, 1 → obstacle
+    gtsam::Matrix funcMap_(rows,cols);
+    funcMap_ = binaryMap_.unaryExpr([](double x)
+    {
+        return x == 1.0 ? 0.0 : std::numeric_limits<double>::max();
+    });
+
+    gtsam::Matrix edt(rows, cols);
+
+    // --- Row-wise pass ---
+    for(size_t r = 0; r < rows; ++r)
+    {
+        Eigen::VectorXd const f = funcMap_.row(r).transpose();
+        edt.row(r)  = computeEuclideanDistanceTransform(f);
+    }
+
+    // --- Pass in y-direction (rows) ---
+    for(size_t c = 0; c< cols; ++c)
+    {
+        Eigen::VectorXd const f = edt.col(c);
+        edt.col(c)  = computeEuclideanDistanceTransform(f);
+    }
+    return edt;
+};
+
+} // namespace anonymous
+
+gtsam::Matrix gpmp2::dt::computeSignedDistanceField(gtsam::Matrix const & binaryMap_, double const cellSize_)
+{
+    gtsam::Matrix const distToObject = computeEDTFromBinary(binaryMap_);
+    gtsam::Matrix const distToObjectSqrt = distToObject.array().sqrt();
+
+    gtsam::Matrix const invBinaryMap = gtsam::Matrix::Ones(binaryMap_.rows(), binaryMap_.cols()) - binaryMap_;
+    gtsam::Matrix const distToBackground = computeEDTFromBinary(invBinaryMap);
+    gtsam::Matrix const distToBackgroundSqrt = distToBackground.array().sqrt();
+
+    return (distToObjectSqrt - distToBackgroundSqrt) * cellSize_;
+}

--- a/gpmp2/obstacle/DistanceTransform.h
+++ b/gpmp2/obstacle/DistanceTransform.h
@@ -16,7 +16,7 @@
 ///        Felzenszwalb & Huttenlocher Algorithm: https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf
 namespace gpmp2::dt
 {
-    /// @brief Rounds matrix to specificed decimation
+    /// @brief Rounds matrix to specified decimation
     /// @param[in] mat_
     /// @param[in] decimals_
     /// @return Rounded to decimation matrix

--- a/gpmp2/obstacle/DistanceTransform.h
+++ b/gpmp2/obstacle/DistanceTransform.h
@@ -16,6 +16,12 @@
 ///        Felzenszwalb & Huttenlocher Algorithm: https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf
 namespace gpmp2::dt
 {
+    /// @brief Rounds matrix to specificed decimation
+    /// @param[in] mat_
+    /// @param[in] decimals_
+    /// @return Rounded to decimation matrix
+    gtsam::Matrix roundMatrix(gtsam::Matrix const & mat_, int const decimals_);
+
     /// @brief Compute the signed distance field of an obstacle-map
     /// @param binaryMap_ (Obstacle map where 1 = obstacle and 0 = free space)
     /// @param cellSize_ resolution of map

--- a/gpmp2/obstacle/DistanceTransform.h
+++ b/gpmp2/obstacle/DistanceTransform.h
@@ -22,6 +22,8 @@ namespace gpmp2::dt
     /// @return Rounded to decimation matrix
     gtsam::Matrix roundMatrix(gtsam::Matrix const & mat_, int const decimals_);
 
+    std::vector<gtsam::Matrix> computeSignedDistanceField(std::vector<gtsam::Matrix> const & binaryMap_, double const cellSize_);
+
     /// @brief Compute the signed distance field of an obstacle-map
     /// @param binaryMap_ (Obstacle map where 1 = obstacle and 0 = free space)
     /// @param cellSize_ resolution of map

--- a/gpmp2/obstacle/DistanceTransform.h
+++ b/gpmp2/obstacle/DistanceTransform.h
@@ -1,0 +1,24 @@
+/**
+ *  @file   DistanceTransform.h
+ *  @brief  Converts distance transform binary 2D and 3D volumes
+ *  @author Matthew King-Smith
+ *  @date   Nov 16, 2025
+ **/
+
+#pragma once
+
+#include <gpmp2/obstacle/PlanarSDF.h>
+#include <gpmp2/obstacle/SignedDistanceField.h>
+
+#include <vector>
+
+/// @note The namespace dt (distance transform) computes signed distance fields according to
+///        Felzenszwalb & Huttenlocher Algorithm: https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf
+namespace gpmp2::dt
+{
+    /// @brief Compute the signed distance field of an obstacle-map
+    /// @param binaryMap_ (Obstacle map where 1 = obstacle and 0 = free space)
+    /// @param cellSize_ resolution of map
+    /// @return signed distance field of binary map
+    gtsam::Matrix computeSignedDistanceField(gtsam::Matrix const & binaryMap_, double const cellSize_);
+} // namespace gpmp2::dt

--- a/gpmp2/obstacle/tests/testDistanceTransform.cpp
+++ b/gpmp2/obstacle/tests/testDistanceTransform.cpp
@@ -115,6 +115,108 @@ TEST(DistanceTransform, diagonal)
     EXPECT((sdf.diagonal().array() < 0).all());
 }
 
+TEST(DistanceTransform3D, single_voxel_center)
+{
+    std::vector<Matrix> vol(5, Matrix::Zero(5,5));
+    vol[2](2,2) = 1;  // center voxel
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    // center slice check
+    Matrix expected(5,5);
+    expected <<
+         std::sqrt(8), std::sqrt(5), 2, std::sqrt(5), std::sqrt(8),
+         std::sqrt(5), std::sqrt(2), 1, std::sqrt(2), std::sqrt(5),
+         2,             1,          -1, 1,          2,
+         std::sqrt(5), std::sqrt(2), 1, std::sqrt(2), std::sqrt(5),
+         std::sqrt(8), std::sqrt(5), 2, std::sqrt(5), std::sqrt(8);
+
+    EXPECT(assert_equal(expected, sdf[2], 1e-6));
+}
+
+TEST(DistanceTransform3D, z_plane)
+{
+    std::vector<Matrix> vol(5, Matrix::Zero(5,5));
+    vol[2].setOnes();  // entire middle slice
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    EXPECT(assert_equal(Matrix::Constant(5,5,2),  sdf[0], 1e-6));
+    EXPECT(assert_equal(Matrix::Constant(5,5,1),  sdf[1], 1e-6));
+    EXPECT(assert_equal(Matrix::Constant(5,5,-1), sdf[2], 1e-6));
+    EXPECT(assert_equal(Matrix::Constant(5,5,1),  sdf[3], 1e-6));
+    EXPECT(assert_equal(Matrix::Constant(5,5,2),  sdf[4], 1e-6));
+}
+
+TEST(DistanceTransform3D, vertical_line)
+{
+    std::vector<Matrix> vol(5, Matrix::Zero(5,5));
+    for (int z = 0; z < 5; z++)
+        vol[z](2,2) = 1;
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    Matrix expected(5,5);
+    expected <<
+        std::sqrt(8), std::sqrt(5), 2, std::sqrt(5), std::sqrt(8),
+        std::sqrt(5), std::sqrt(2), 1, std::sqrt(2), std::sqrt(5),
+        2,             1,          -1, 1,          2,
+        std::sqrt(5), std::sqrt(2), 1, std::sqrt(2), std::sqrt(5),
+        std::sqrt(8), std::sqrt(5), 2, std::sqrt(5), std::sqrt(8);
+
+    // all slices identical
+    for (int z = 0; z < 5; z++)
+        EXPECT(assert_equal(expected, sdf[z], 1e-6));
+}
+
+TEST(DistanceTransform3D, corner_voxel)
+{
+    std::vector<Matrix> vol(5, Matrix::Zero(5,5));
+    vol[0](0,0) = 1;
+
+    auto sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    EXPECT(assert_equal(sdf[0](0,0), -1.0, 1e-6));
+    EXPECT(assert_equal(sdf[0](1,0),  1.0, 1e-6));
+    EXPECT(assert_equal(sdf[1](0,0),  1.0, 1e-6));
+    EXPECT(assert_equal(sdf[1](1,1),  std::sqrt(3), 1e-6));
+}
+
+TEST(DistanceTransform3D, solid_cube)
+{
+    std::vector<Matrix> vol(5, Matrix::Zero(5,5));
+
+    for (int z = 1; z <= 3; z++)
+        vol[z].block(1,1,3,3).setOnes();
+
+    auto sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    EXPECT(assert_equal(sdf[2](2,2), -2.0, 1e-6)); // center deepest
+    EXPECT(assert_equal(sdf[2](1,1), -1.0, 1e-6)); // surface
+    EXPECT(assert_equal(sdf[0](2,2), 1.0, 1e-6)); // outside above
+}
+
+TEST(DistanceTransform3D, empty_map)
+{
+    std::vector<Matrix> vol(5, Matrix::Zero(5,5));
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    // depends on your convention — often large positive or INF
+    for (int z = 0; z < 5; z++)
+        EXPECT(sdf[z].array().isFinite().all());
+}
+
+TEST(DistanceTransform3D, full_map)
+{
+    std::vector<Matrix> vol(5, Matrix::Ones(5,5));
+
+    auto sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
+
+    for (int z = 0; z < 5; z++)
+        EXPECT((sdf[z].array() <= 0).all());
+}
+
 /* ************************************************************************** */
 /* main function */
 int main() {

--- a/gpmp2/obstacle/tests/testDistanceTransform.cpp
+++ b/gpmp2/obstacle/tests/testDistanceTransform.cpp
@@ -1,0 +1,123 @@
+/**
+ *  @file   testDistanceTransform.cpp
+ *  @brief  Test cases when converting obstacle map to signed distance field
+ *  @author Matthew King-Smith
+ *  @date   Apr 25, 2026
+ **/
+
+#include <CppUnitLite/TestHarness.h>
+#include <gtsam/base/Matrix.h>
+#include <gpmp2/obstacle/DistanceTransform.h>
+
+#include <iostream>
+
+using namespace std;
+using namespace gtsam;
+using namespace gpmp2;
+
+TEST(DistanceTransform, single_pixel) {
+    Matrix singleObstacleMap {Matrix::Zero(3,3)};
+    singleObstacleMap << 0, 0, 0,
+                         0, 1, 0,
+                         0, 0, 0;
+
+    Matrix expectedSDF(3,3);
+    expectedSDF << sqrt(2), 1, sqrt(2),
+                   1,       -1, 1,
+                   sqrt(2), 1, sqrt(2);
+
+    const auto computedSDF = gpmp2::dt::computeSignedDistanceField(singleObstacleMap, 1.0);
+
+    EXPECT(assert_equal(expectedSDF, computedSDF, 1e-6));
+}
+
+TEST(DistanceTransform, empty)
+{
+    Matrix const m = Matrix::Zero(3,3);
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(m, 1.0);
+
+    // convention: large positive everywhere
+    EXPECT((sdf.array() > 0).all());
+}
+
+TEST(DistanceTransform, full)
+{
+    Matrix const m = Matrix::Ones(3,3);
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(m, 1.0);
+
+    // everything inside obstacle → negative
+    EXPECT((sdf.array() <= 0).all());
+}
+
+TEST(DistanceTransform, horizontal_line)
+{
+    Matrix m = Matrix::Zero(5,5);
+    m.row(2).setOnes();
+
+    Matrix expected(5,5);
+    expected <<
+        2, 2, 2, 2, 2,
+        1, 1, 1, 1, 1,
+       -1,-1,-1,-1,-1,
+        1, 1, 1, 1, 1,
+        2, 2, 2, 2, 2;
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(m, 1.0);
+    EXPECT(assert_equal(expected, sdf, 1e-6));
+}
+
+TEST(DistanceTransform, vertical_line)
+{
+    Matrix m = Matrix::Zero(5,5);
+    m.col(2).setOnes();
+
+    Matrix expected(5,5);
+    expected <<
+        2, 1,-1, 1, 2,
+        2, 1,-1, 1, 2,
+        2, 1,-1, 1, 2,
+        2, 1,-1, 1, 2,
+        2, 1,-1, 1, 2;
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(m, 1.0);
+    EXPECT(assert_equal(expected, sdf, 1e-6));
+}
+
+TEST(DistanceTransform, square_block)
+{
+    Matrix m = Matrix::Zero(5,5);
+    m.block(1,1,3,3).setOnes();
+
+    Matrix expected(5,5);
+    expected <<
+        sqrt(2), 1, 1, 1, sqrt(2),
+        1,      -1,-1,-1, 1,
+        1,      -1,-2,-1, 1,
+        1,      -1,-1,-1, 1,
+        sqrt(2), 1, 1, 1, sqrt(2);
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(m, 1.0);
+    EXPECT(assert_equal(expected, sdf, 1e-6));
+}
+
+TEST(DistanceTransform, diagonal)
+{
+    Matrix m = Matrix::Zero(3,3);
+    m(0,0) = 1;
+    m(1,1) = 1;
+    m(2,2) = 1;
+
+    auto const sdf = gpmp2::dt::computeSignedDistanceField(m, 1.0);
+
+    // just check invariants (exact values messy)
+    EXPECT((sdf.diagonal().array() < 0).all());
+}
+
+/* ************************************************************************** */
+/* main function */
+int main() {
+    TestResult tr;
+    return TestRegistry::runAllTests(tr);
+}

--- a/gpmp2/obstacle/tests/testDistanceTransform.cpp
+++ b/gpmp2/obstacle/tests/testDistanceTransform.cpp
@@ -202,7 +202,6 @@ TEST(DistanceTransform3D, empty_map)
 
     auto const sdf = gpmp2::dt::computeSignedDistanceField(vol, 1.0);
 
-    // depends on your convention — often large positive or INF
     for (int z = 0; z < 5; z++)
         EXPECT(sdf[z].array().isFinite().all());
 }

--- a/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorArm.cpp
+++ b/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorArm.cpp
@@ -5,6 +5,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gpmp2/obstacle/ObstaclePlanarSDFFactorArm.h>
+#include <gpmp2/obstacle/DistanceTransform.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -54,7 +55,10 @@ TEST(ObstaclePlanarSDFFactorArm, data) {
   Point2 origin(0, 0);
   double cell_size = 1.0;
 
-  sdf = PlanarSDF(origin, cell_size, field);
+  Matrix signedDistField = gpmp2::dt::computeSignedDistanceField(map_ground_truth, cell_size);
+  signedDistField = gpmp2::dt::roundMatrix(signedDistField, 4);
+  EXPECT(assert_equal(field, signedDistField, 1e-6));
+  sdf = PlanarSDF(origin, cell_size, signedDistField);
 }
 
 /* ************************************************************************** */

--- a/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorGPArm.cpp
+++ b/gpmp2/obstacle/tests/testObstaclePlanarSDFFactorGPArm.cpp
@@ -5,6 +5,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gpmp2/obstacle/ObstaclePlanarSDFFactorGPArm.h>
+#include <gpmp2/obstacle/DistanceTransform.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -57,8 +58,10 @@ TEST(ObstaclePlanarSDFFactorGPArm, data) {
 
   Point2 origin(0, 0);
   double cell_size = 1.0;
-
-  sdf2 = PlanarSDF(origin, cell_size, field2);
+  Matrix signedDistField = gpmp2::dt::computeSignedDistanceField(map_ground_truth2, cell_size);
+  signedDistField = gpmp2::dt::roundMatrix(signedDistField, 4);
+  EXPECT(assert_equal(field2, signedDistField, 1e-6));
+  sdf2 = PlanarSDF(origin, cell_size, signedDistField);
 }
 
 /* ************************************************************************** */

--- a/gpmp2/obstacle/tests/testObstacleSDFFactorArm.cpp
+++ b/gpmp2/obstacle/tests/testObstacleSDFFactorArm.cpp
@@ -6,6 +6,7 @@
 #include <CppUnitLite/TestHarness.h>
 #include <gpmp2/kinematics/ArmModel.h>
 #include <gpmp2/obstacle/ObstacleSDFFactor.h>
+#include <gpmp2/obstacle/DistanceTransform.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -68,7 +69,18 @@ TEST(ObstacleSDFFactorArm, data) {
               0.3464, 0.3000, 0.2828, 0.2828, 0.2828, 0.3000, 0.3464)
                  .finished();
 
-  sdf = SignedDistanceField(origin, cell_size, field);
+  std::vector<Matrix> obstacleMap(3, Matrix::Zero(7,7));
+  // obstacle only in first slice
+  obstacleMap[0].block(2,2,3,3).setOnes();
+
+  auto computedSDF = gpmp2::dt::computeSignedDistanceField(obstacleMap, cell_size);
+  for(size_t ii(0); ii < computedSDF.size(); ++ii)
+  {
+      computedSDF.at(ii) = gpmp2::dt::roundMatrix(computedSDF.at(ii), 4);
+      EXPECT(assert_equal(field.at(ii), computedSDF.at(ii), 1e-6));
+  }
+
+  sdf = SignedDistanceField(origin, cell_size, computedSDF);
 }
 
 /* ************************************************************************** */

--- a/gpmp2/obstacle/tests/testObstacleSDFFactorGPArm.cpp
+++ b/gpmp2/obstacle/tests/testObstacleSDFFactorGPArm.cpp
@@ -5,6 +5,7 @@
 
 #include <CppUnitLite/TestHarness.h>
 #include <gpmp2/obstacle/ObstacleSDFFactorGPArm.h>
+#include <gpmp2/obstacle/DistanceTransform.h>
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Testable.h>
 #include <gtsam/base/numericalDerivative.h>
@@ -67,7 +68,18 @@ TEST(ObstacleSDFFactorGPArm, data) {
               0.3464, 0.3000, 0.2828, 0.2828, 0.2828, 0.3000, 0.3464)
                  .finished();
 
-  sdf2 = SignedDistanceField(origin, cell_size, field);
+  std::vector<Matrix> obstacleMap(3, Matrix::Zero(7,7));
+  // obstacle only in first slice
+  obstacleMap[0].block(2,2,3,3).setOnes();
+
+  auto computedSDF = gpmp2::dt::computeSignedDistanceField(obstacleMap, cell_size);
+  for(size_t ii(0); ii < computedSDF.size(); ++ii)
+  {
+      computedSDF.at(ii) = gpmp2::dt::roundMatrix(computedSDF.at(ii), 4);
+      EXPECT(assert_equal(field.at(ii), computedSDF.at(ii), 1e-6));
+  }
+
+  sdf2 = SignedDistanceField(origin, cell_size, computedSDF);
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
# Purpose
Compute the Euclidean Distance Transform (EDT) of Binary Obstacle maps in 2/3D in C++. This alleviates the need for external libraries like MATLAB and Python to compute EDT of binary images with functions like: [bwdist](https://www.mathworks.com/help/images/ref/bwdist.html) and [scipy.ndimage.distance_transform_edt](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.distance_transform_edt.html).

# Details
- The C++ algorithm implements the [Felzenszwalb & Huttenlocher Algorithm](https://cs.brown.edu/people/pfelzens/papers/dt-final.pdf) to determine EDT of binary obstacles
- Introduced namespace `dt` (distance transform) under `gpmp2`
- Wrote unit tests with analytic cases for single and multidimensional signed distance fields
- Validated EDT implementation against existing tests